### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/174/365/421174365.geojson
+++ b/data/421/174/365/421174365.geojson
@@ -294,6 +294,9 @@
     },
     "wof:country":"IR",
     "wof:created":1459009028,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"129c3dc6421a1fcdb0c17c357b201259",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         }
     ],
     "wof:id":421174365,
-    "wof:lastmodified":1566719314,
+    "wof:lastmodified":1582317683,
     "wof:name":"Sirjan",
     "wof:parent_id":1108720461,
     "wof:placetype":"locality",

--- a/data/421/187/075/421187075.geojson
+++ b/data/421/187/075/421187075.geojson
@@ -274,6 +274,9 @@
     },
     "wof:country":"IR",
     "wof:created":1459009501,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"ab09aa76c938bf92e746fd21af34da53",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
         }
     ],
     "wof:id":421187075,
-    "wof:lastmodified":1566719315,
+    "wof:lastmodified":1582317683,
     "wof:name":"Dezful",
     "wof:parent_id":1108719969,
     "wof:placetype":"locality",

--- a/data/421/188/949/421188949.geojson
+++ b/data/421/188/949/421188949.geojson
@@ -326,6 +326,9 @@
     },
     "wof:country":"IR",
     "wof:created":1459009589,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"fbbc0b3ec97a0f7a5e84a7ebd4c07ebf",
     "wof:hierarchy":[
         {
@@ -337,7 +340,7 @@
         }
     ],
     "wof:id":421188949,
-    "wof:lastmodified":1566719316,
+    "wof:lastmodified":1582317683,
     "wof:name":"Birjand",
     "wof:parent_id":1108719895,
     "wof:placetype":"locality",

--- a/data/421/203/959/421203959.geojson
+++ b/data/421/203/959/421203959.geojson
@@ -237,6 +237,9 @@
     },
     "wof:country":"IR",
     "wof:created":1459010169,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"2c5b3ec4afaf2a5e28f355dc69efac82",
     "wof:hierarchy":[
         {
@@ -248,7 +251,7 @@
         }
     ],
     "wof:id":421203959,
-    "wof:lastmodified":1566719313,
+    "wof:lastmodified":1582317683,
     "wof:name":"Marv Dasht",
     "wof:parent_id":1108720223,
     "wof:placetype":"locality",

--- a/data/421/204/533/421204533.geojson
+++ b/data/421/204/533/421204533.geojson
@@ -724,6 +724,9 @@
     },
     "wof:country":"IR",
     "wof:created":1459010189,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66115eeca640c90c170bb02c506d1fea",
     "wof:hierarchy":[
         {
@@ -735,7 +738,7 @@
         }
     ],
     "wof:id":421204533,
-    "wof:lastmodified":1566719311,
+    "wof:lastmodified":1582317683,
     "wof:name":"Tehran",
     "wof:parent_id":1108720491,
     "wof:placetype":"locality",

--- a/data/856/323/61/85632361.geojson
+++ b/data/856/323/61/85632361.geojson
@@ -1121,6 +1121,11 @@
     },
     "wof:country":"IR",
     "wof:country_alpha3":"IRN",
+    "wof:geom_alt":[
+        "naturalearth",
+        "meso",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"4c2e8e0977af76450919590d97357378",
     "wof:hierarchy":[
         {
@@ -1135,7 +1140,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716588,
+    "wof:lastmodified":1582317591,
     "wof:name":"Iran",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/722/83/85672283.geojson
+++ b/data/856/722/83/85672283.geojson
@@ -363,6 +363,9 @@
         "wk:page":"Kohgiluyeh and Boyer-Ahmad Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f5a70284e2197b14bc851cb37b188490",
     "wof:hierarchy":[
         {
@@ -378,7 +381,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716588,
+    "wof:lastmodified":1582317590,
     "wof:name":"Kohgiluyeh and Buyer Ahmad",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/722/89/85672289.geojson
+++ b/data/856/722/89/85672289.geojson
@@ -390,6 +390,9 @@
         "wk:page":"Bushehr Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b17c31ac38be34c25eb980ff56b75ac",
     "wof:hierarchy":[
         {
@@ -405,7 +408,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716586,
+    "wof:lastmodified":1582317589,
     "wof:name":"Bushehr",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/722/91/85672291.geojson
+++ b/data/856/722/91/85672291.geojson
@@ -398,6 +398,9 @@
         "wk:page":"Isfahan Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ca736e3ec1c932985928539c9655e08a",
     "wof:hierarchy":[
         {
@@ -413,7 +416,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716587,
+    "wof:lastmodified":1582317589,
     "wof:name":"Esfahan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/722/95/85672295.geojson
+++ b/data/856/722/95/85672295.geojson
@@ -398,6 +398,9 @@
         "wk:page":"Fars Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3c4f07fe47630c5b599e536ad6c6703b",
     "wof:hierarchy":[
         {
@@ -413,7 +416,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716586,
+    "wof:lastmodified":1582317589,
     "wof:name":"Fars",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/722/99/85672299.geojson
+++ b/data/856/722/99/85672299.geojson
@@ -369,6 +369,9 @@
         "wk:page":"Golestan Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a3b8fca851080def02bbcff302452c10",
     "wof:hierarchy":[
         {
@@ -384,7 +387,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716587,
+    "wof:lastmodified":1582317590,
     "wof:name":"Golestan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/03/85672303.geojson
+++ b/data/856/723/03/85672303.geojson
@@ -398,6 +398,9 @@
         "wk:page":"Mazandaran Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5ca566fa021937d07a46259a26eb3583",
     "wof:hierarchy":[
         {
@@ -413,7 +416,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716595,
+    "wof:lastmodified":1582317598,
     "wof:name":"Mazandaran",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/09/85672309.geojson
+++ b/data/856/723/09/85672309.geojson
@@ -361,6 +361,9 @@
         "wk:page":"Semnan Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e07467767b6ae4a919eed146bca9b553",
     "wof:hierarchy":[
         {
@@ -376,7 +379,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716598,
+    "wof:lastmodified":1582317601,
     "wof:name":"Semnan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/13/85672313.geojson
+++ b/data/856/723/13/85672313.geojson
@@ -391,6 +391,9 @@
         "wk:page":"Tehran Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e4befa7cfaf74e4dd9e3c39ce5c5a75",
     "wof:hierarchy":[
         {
@@ -406,7 +409,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716601,
+    "wof:lastmodified":1582317603,
     "wof:name":"Tehran",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/17/85672317.geojson
+++ b/data/856/723/17/85672317.geojson
@@ -341,6 +341,9 @@
         "wk:page":"Yazd Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"92f11ff3161179cdb27c88359dceaf9f",
     "wof:hierarchy":[
         {
@@ -356,7 +359,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716598,
+    "wof:lastmodified":1582317600,
     "wof:name":"Yazd",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/19/85672319.geojson
+++ b/data/856/723/19/85672319.geojson
@@ -376,6 +376,9 @@
         "wk:page":"Chaharmahal and Bakhtiari Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"979e679c1fd2ce6c29ce3674d2ad1ab6",
     "wof:hierarchy":[
         {
@@ -391,7 +394,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716598,
+    "wof:lastmodified":1582317600,
     "wof:name":"Chahar Mahall and Bakhtiari",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/25/85672325.geojson
+++ b/data/856/723/25/85672325.geojson
@@ -391,6 +391,9 @@
         "wk:page":"Khuzestan Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5c130229e4218761b7e322be67e14997",
     "wof:hierarchy":[
         {
@@ -406,7 +409,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716601,
+    "wof:lastmodified":1582317603,
     "wof:name":"Khuzestan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/29/85672329.geojson
+++ b/data/856/723/29/85672329.geojson
@@ -378,6 +378,9 @@
         "wk:page":"Lorestan Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e06ed559ccb088f98c54952b9bacc37",
     "wof:hierarchy":[
         {
@@ -393,7 +396,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716597,
+    "wof:lastmodified":1582317599,
     "wof:name":"Lorestan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/33/85672333.geojson
+++ b/data/856/723/33/85672333.geojson
@@ -355,6 +355,9 @@
         "wk:page":"Ilam Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0efdca9276ef3a51866cb6e31b8967a2",
     "wof:hierarchy":[
         {
@@ -370,7 +373,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716596,
+    "wof:lastmodified":1582317599,
     "wof:name":"Ilam",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/37/85672337.geojson
+++ b/data/856/723/37/85672337.geojson
@@ -349,6 +349,9 @@
         "wk:page":"Hormozgan Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7d087f536f068eb22917d1b335716e13",
     "wof:hierarchy":[
         {
@@ -364,7 +367,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716599,
+    "wof:lastmodified":1582317601,
     "wof:name":"Hormozgan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/43/85672343.geojson
+++ b/data/856/723/43/85672343.geojson
@@ -381,6 +381,9 @@
         "wk:page":"Ardabil Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f847fee8ad8437bedae870cf46c20261",
     "wof:hierarchy":[
         {
@@ -396,7 +399,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716598,
+    "wof:lastmodified":1582317600,
     "wof:name":"Ardebil",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/47/85672347.geojson
+++ b/data/856/723/47/85672347.geojson
@@ -363,6 +363,9 @@
         "wk:page":"Markazi Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b8b94ce71c493f2aaabf582c60268741",
     "wof:hierarchy":[
         {
@@ -378,7 +381,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716601,
+    "wof:lastmodified":1582317603,
     "wof:name":"Markazi",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/51/85672351.geojson
+++ b/data/856/723/51/85672351.geojson
@@ -361,6 +361,9 @@
         "wk:page":"Qom Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"709d9d6a7938f10837955c930cbd51be",
     "wof:hierarchy":[
         {
@@ -376,7 +379,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716596,
+    "wof:lastmodified":1582317598,
     "wof:name":"Qom",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/55/85672355.geojson
+++ b/data/856/723/55/85672355.geojson
@@ -369,6 +369,9 @@
         "wk:page":"Hamadan Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"625aece6e6a0fbb9eba9f427bbfceda4",
     "wof:hierarchy":[
         {
@@ -384,7 +387,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716599,
+    "wof:lastmodified":1582317602,
     "wof:name":"Hamadan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/61/85672361.geojson
+++ b/data/856/723/61/85672361.geojson
@@ -352,6 +352,9 @@
         "wk:page":"Zanjan Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9906750575d573ca6a40f6ddd1aef7d8",
     "wof:hierarchy":[
         {
@@ -367,7 +370,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716595,
+    "wof:lastmodified":1582317597,
     "wof:name":"Zanjan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/67/85672367.geojson
+++ b/data/856/723/67/85672367.geojson
@@ -345,6 +345,9 @@
         "wk:page":"Qazvin Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"890e4beec71f10f7b99ae6bee48f011b",
     "wof:hierarchy":[
         {
@@ -360,7 +363,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716596,
+    "wof:lastmodified":1582317599,
     "wof:name":"Qazvin",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/69/85672369.geojson
+++ b/data/856/723/69/85672369.geojson
@@ -362,6 +362,9 @@
         "wk:page":"West Azerbaijan Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"36b62e0caeb7ba674f6624d85bbdd0c4",
     "wof:hierarchy":[
         {
@@ -377,7 +380,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716595,
+    "wof:lastmodified":1582317598,
     "wof:name":"West Azerbaijan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/73/85672373.geojson
+++ b/data/856/723/73/85672373.geojson
@@ -372,6 +372,9 @@
         "wk:page":"East Azerbaijan Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"79501c63f1f82af0294785e0de26c239",
     "wof:hierarchy":[
         {
@@ -387,7 +390,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716597,
+    "wof:lastmodified":1582317599,
     "wof:name":"East Azerbaijan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/79/85672379.geojson
+++ b/data/856/723/79/85672379.geojson
@@ -349,6 +349,9 @@
         "wk:page":"Kermanshah Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"41216da0f48f21655f127be0bd8b20b2",
     "wof:hierarchy":[
         {
@@ -364,7 +367,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716600,
+    "wof:lastmodified":1582317602,
     "wof:name":"Kermanshah",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/83/85672383.geojson
+++ b/data/856/723/83/85672383.geojson
@@ -391,6 +391,9 @@
         "wk:page":"Gilan Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6811bcedd3b7a71d631027f152f12c6c",
     "wof:hierarchy":[
         {
@@ -406,7 +409,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716601,
+    "wof:lastmodified":1582317603,
     "wof:name":"Gilan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/87/85672387.geojson
+++ b/data/856/723/87/85672387.geojson
@@ -370,6 +370,9 @@
         "wk:page":"Kurdistan Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d19cbf06f1c7b37625f970a005e3b544",
     "wof:hierarchy":[
         {
@@ -385,7 +388,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716597,
+    "wof:lastmodified":1582317600,
     "wof:name":"Kordestan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/91/85672391.geojson
+++ b/data/856/723/91/85672391.geojson
@@ -392,6 +392,9 @@
         "wd:id":"Q171551"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"efcf96312aa59fb2b696516f00ca829a",
     "wof:hierarchy":[
         {
@@ -407,7 +410,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716599,
+    "wof:lastmodified":1582317601,
     "wof:name":"South Khorasan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/97/85672397.geojson
+++ b/data/856/723/97/85672397.geojson
@@ -388,6 +388,9 @@
         "wd:id":"Q587090"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c72a2404c3fb06bc9bc72d13d1820faf",
     "wof:hierarchy":[
         {
@@ -403,7 +406,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716600,
+    "wof:lastmodified":1582317602,
     "wof:name":"Razavi Khorasan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/724/01/85672401.geojson
+++ b/data/856/724/01/85672401.geojson
@@ -383,6 +383,9 @@
         "wd:id":"Q180075"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f6eeef2dd5c23aebea0f5ca81340f01",
     "wof:hierarchy":[
         {
@@ -398,7 +401,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716594,
+    "wof:lastmodified":1582317597,
     "wof:name":"North Khorasan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/724/05/85672405.geojson
+++ b/data/856/724/05/85672405.geojson
@@ -405,6 +405,9 @@
         "wk:page":"Sistan and Baluchestan Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6b4c4e9db916cade1965daecf7f9af7f",
     "wof:hierarchy":[
         {
@@ -420,7 +423,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716593,
+    "wof:lastmodified":1582317596,
     "wof:name":"Sistan and Baluchestan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/724/09/85672409.geojson
+++ b/data/856/724/09/85672409.geojson
@@ -355,6 +355,9 @@
         "wk:page":"Kerman Province"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"08423f5da89cc6b0248f1b6e8fdf6d83",
     "wof:hierarchy":[
         {
@@ -370,7 +373,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716594,
+    "wof:lastmodified":1582317596,
     "wof:name":"Kerman",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/724/15/85672415.geojson
+++ b/data/856/724/15/85672415.geojson
@@ -351,6 +351,9 @@
         "wd:id":"Q484725"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e33ace97397e31788d2514ffaf86598e",
     "wof:hierarchy":[
         {
@@ -366,7 +369,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1566716594,
+    "wof:lastmodified":1582317597,
     "wof:name":"Alborz",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/857/941/49/85794149.geojson
+++ b/data/857/941/49/85794149.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Artane, Dublin"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"db2b20ac401b0b873a025efa1f67eebb",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716582,
+    "wof:lastmodified":1582317587,
     "wof:name":"Artane",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/941/53/85794153.geojson
+++ b/data/857/941/53/85794153.geojson
@@ -76,6 +76,9 @@
         "qs_pg:id":900998
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0d660bc3dbd6c0c2e5fac9d5852fee93",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716582,
+    "wof:lastmodified":1582317587,
     "wof:name":"Ashtown",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/941/67/85794167.geojson
+++ b/data/857/941/67/85794167.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Ballsbridge"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6dfc4a23262fcb0cade9b638d5d359ba",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716581,
+    "wof:lastmodified":1582317587,
     "wof:name":"Ballsbridge",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/941/73/85794173.geojson
+++ b/data/857/941/73/85794173.geojson
@@ -89,6 +89,9 @@
         "wd:id":"Q4076739"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ab32f88b20641e21e67e058c7d1742ec",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716582,
+    "wof:lastmodified":1582317587,
     "wof:name":"Ballybrack",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/941/77/85794177.geojson
+++ b/data/857/941/77/85794177.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Ballyfermot"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"32a1a8eeaeb243d616874efb24282f89",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716582,
+    "wof:lastmodified":1582317587,
     "wof:name":"Ballyfermot",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/941/81/85794181.geojson
+++ b/data/857/941/81/85794181.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Ballymun"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e808a9a398fddf126cf313b3725a955b",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716582,
+    "wof:lastmodified":1582317587,
     "wof:name":"Ballymun",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/941/87/85794187.geojson
+++ b/data/857/941/87/85794187.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Beaumont, Dublin"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"73bdd986399de34122e3c38909fb0b04",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716582,
+    "wof:lastmodified":1582317587,
     "wof:name":"Beaumont",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/941/91/85794191.geojson
+++ b/data/857/941/91/85794191.geojson
@@ -159,6 +159,9 @@
         "wk:page":"Fressac"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6de59b8249f47e1515e46e6095bc7759",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716582,
+    "wof:lastmodified":1582317587,
     "wof:name":"Blackpool",
     "wof:parent_id":101751727,
     "wof:placetype":"neighbourhood",

--- a/data/857/941/97/85794197.geojson
+++ b/data/857/941/97/85794197.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Booterstown"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"de34e49b4a0359a14ce1a5560f1e9d9e",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716582,
+    "wof:lastmodified":1582317587,
     "wof:name":"Booterstown",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/942/07/85794207.geojson
+++ b/data/857/942/07/85794207.geojson
@@ -109,6 +109,9 @@
         "qs_pg:id":478975
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8bd158ac4c37e1eee237c6b9f09814c4",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716583,
+    "wof:lastmodified":1582317587,
     "wof:name":"Cabra",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/942/11/85794211.geojson
+++ b/data/857/942/11/85794211.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Carrickmines"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"722f204f09deb65a757d0b40b0c1abad",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716583,
+    "wof:lastmodified":1582317587,
     "wof:name":"Carrickmines",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/942/15/85794215.geojson
+++ b/data/857/942/15/85794215.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Chapelizod"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"349b06af22741c5f7b9fadeb8da0361d",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716583,
+    "wof:lastmodified":1582317587,
     "wof:name":"Chapelizod",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/942/31/85794231.geojson
+++ b/data/857/942/31/85794231.geojson
@@ -458,6 +458,9 @@
         "wd:id":"Q22657"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"158a17d8a8c0a1c581fb18ba11894295",
     "wof:hierarchy":[
         {
@@ -472,7 +475,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716583,
+    "wof:lastmodified":1582317587,
     "wof:name":"Concrete",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/942/35/85794235.geojson
+++ b/data/857/942/35/85794235.geojson
@@ -88,6 +88,9 @@
         "wk:page":"Coolock"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cf1db47728afef89ff375263461d0699",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716582,
+    "wof:lastmodified":1582317587,
     "wof:name":"Coolock",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/942/49/85794249.geojson
+++ b/data/857/942/49/85794249.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Deansgrange"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4079f412ba9d3cfc0e6d38c2e0c21373",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716584,
+    "wof:lastmodified":1582317587,
     "wof:name":"Deans Grange",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/942/57/85794257.geojson
+++ b/data/857/942/57/85794257.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Donnybrook, Dublin"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4e21d4957ab719d55063e28850d6cd40",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716582,
+    "wof:lastmodified":1582317587,
     "wof:name":"Donnybrook",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/942/61/85794261.geojson
+++ b/data/857/942/61/85794261.geojson
@@ -97,6 +97,9 @@
         "wd:id":"Q693683"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ec2000421d79106d973d0288f760940d",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716582,
+    "wof:lastmodified":1582317587,
     "wof:name":"Drimnagh",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/942/65/85794265.geojson
+++ b/data/857/942/65/85794265.geojson
@@ -83,6 +83,9 @@
         "qs_pg:id":454674
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b5d244d70a5941c2a56a9a513e4ba25f",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716583,
+    "wof:lastmodified":1582317587,
     "wof:name":"Drumcondra",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/942/69/85794269.geojson
+++ b/data/857/942/69/85794269.geojson
@@ -143,6 +143,9 @@
         "wk:page":"Dundrum, Dublin"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"68f33546d5dcb2accfe11244d9e95a26",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716583,
+    "wof:lastmodified":1582317587,
     "wof:name":"Dundrum",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/942/75/85794275.geojson
+++ b/data/857/942/75/85794275.geojson
@@ -131,6 +131,9 @@
         "wk:page":"Finglas"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"df9d519c031ff19f90672e7e62aaaa9c",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716583,
+    "wof:lastmodified":1582317587,
     "wof:name":"Finglas",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/942/81/85794281.geojson
+++ b/data/857/942/81/85794281.geojson
@@ -131,6 +131,9 @@
         "wk:page":"Firhouse"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bb8c865d8730bac1613cd6f749580882",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716583,
+    "wof:lastmodified":1582317587,
     "wof:name":"Firhouse",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/942/85/85794285.geojson
+++ b/data/857/942/85/85794285.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Goatstown"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dcec36dde095701146ff1b116f5dbe96",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716584,
+    "wof:lastmodified":1582317587,
     "wof:name":"Goatstown",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/942/89/85794289.geojson
+++ b/data/857/942/89/85794289.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Irishtown, Dublin"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"be5b79bcc04f97bc63767a7e842b1572",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716583,
+    "wof:lastmodified":1582317587,
     "wof:name":"Irishtown",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/942/99/85794299.geojson
+++ b/data/857/942/99/85794299.geojson
@@ -73,6 +73,9 @@
         "qs_pg:id":1082939
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6c9ce3879c4f3baa55ef5ea3331950fd",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716583,
+    "wof:lastmodified":1582317587,
     "wof:name":"Kill of the Grange",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/05/85794305.geojson
+++ b/data/857/943/05/85794305.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Kilmainham"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b5d498535216bdf466893c2628e28c76",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716585,
+    "wof:lastmodified":1582317588,
     "wof:name":"Kilmainham",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/11/85794311.geojson
+++ b/data/857/943/11/85794311.geojson
@@ -90,6 +90,9 @@
         "qs_pg:id":228797
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"75a548d314ee48a5d9876619c21470f2",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716585,
+    "wof:lastmodified":1582317588,
     "wof:name":"Kilmore",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/15/85794315.geojson
+++ b/data/857/943/15/85794315.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Kimmage"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"69970a12b140cf5d2a72e503a6434956",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716586,
+    "wof:lastmodified":1582317588,
     "wof:name":"Kimmage",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/19/85794319.geojson
+++ b/data/857/943/19/85794319.geojson
@@ -88,6 +88,9 @@
         "wk:page":"Marino, Dublin"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"31dbcb98bfaf2c104529dc1bfbc9c8bb",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716585,
+    "wof:lastmodified":1582317588,
     "wof:name":"Marino",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/23/85794323.geojson
+++ b/data/857/943/23/85794323.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":901640
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e79f136fbca9849fc096edf418f7d11b",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716585,
+    "wof:lastmodified":1582317588,
     "wof:name":"Millfield",
     "wof:parent_id":101751727,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/29/85794329.geojson
+++ b/data/857/943/29/85794329.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Milltown, Dublin"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fe78714d056320e9ac77ba3002dc7979",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716585,
+    "wof:lastmodified":1582317588,
     "wof:name":"Milltown",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/37/85794337.geojson
+++ b/data/857/943/37/85794337.geojson
@@ -89,6 +89,9 @@
         "qs_pg:id":1078449
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"af81f5b843f2b83be1c774bab239b5a1",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716585,
+    "wof:lastmodified":1582317588,
     "wof:name":"Mount Argus",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/47/85794347.geojson
+++ b/data/857/943/47/85794347.geojson
@@ -163,6 +163,9 @@
         "wk:page":"Wancourt"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4b2ca2726439d0bdfe4d1ecd901bb21b",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716586,
+    "wof:lastmodified":1582317588,
     "wof:name":"Palmerston",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/49/85794349.geojson
+++ b/data/857/943/49/85794349.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Phibsborough"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"39d7f7d837d7901c4077c53514a67866",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716586,
+    "wof:lastmodified":1582317588,
     "wof:name":"Phibsborough",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/53/85794353.geojson
+++ b/data/857/943/53/85794353.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Raheny"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5327c6df242710420349b4ed75702b4d",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716585,
+    "wof:lastmodified":1582317588,
     "wof:name":"Raheny",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/57/85794357.geojson
+++ b/data/857/943/57/85794357.geojson
@@ -129,6 +129,9 @@
         "wk:page":"Rathfarnham"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"78fc4a9911ec8e4e30911454ea4153f9",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716585,
+    "wof:lastmodified":1582317588,
     "wof:name":"Rathfarnham",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/61/85794361.geojson
+++ b/data/857/943/61/85794361.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Rathmines"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a4fd75a4669bb36599357886a704d19a",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716584,
+    "wof:lastmodified":1582317588,
     "wof:name":"Rathmines",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/67/85794367.geojson
+++ b/data/857/943/67/85794367.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Ringsend"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"44af017ba5e5b0161fc559bb1418da8d",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716585,
+    "wof:lastmodified":1582317588,
     "wof:name":"Ringsend",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/71/85794371.geojson
+++ b/data/857/943/71/85794371.geojson
@@ -69,6 +69,9 @@
         "qs_pg:id":897857
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"65880d4c50618dadfe83fa06bcbb5694",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716586,
+    "wof:lastmodified":1582317588,
     "wof:name":"Roundtown",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/75/85794375.geojson
+++ b/data/857/943/75/85794375.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Sallynoggin"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1b0260859989baf9a9b5e9e7a4397cf2",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716585,
+    "wof:lastmodified":1582317588,
     "wof:name":"Sallynogin",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/87/85794387.geojson
+++ b/data/857/943/87/85794387.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Santry"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"06cb134eec9c641f055315d2f1ae8543",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716585,
+    "wof:lastmodified":1582317588,
     "wof:name":"Santry",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/91/85794391.geojson
+++ b/data/857/943/91/85794391.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Stillorgan"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"49855d0bf10ca9456608f28329c25e07",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716585,
+    "wof:lastmodified":1582317588,
     "wof:name":"Stillorgan",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/943/95/85794395.geojson
+++ b/data/857/943/95/85794395.geojson
@@ -170,6 +170,9 @@
         "wk:page":"Tallaght"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c16c132123733a1140eb59457c2652c5",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716584,
+    "wof:lastmodified":1582317588,
     "wof:name":"Tallaght",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/944/01/85794401.geojson
+++ b/data/857/944/01/85794401.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Templeogue"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"044acdc2c3dec5567e3698b62db52c07",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716584,
+    "wof:lastmodified":1582317587,
     "wof:name":"Templeoge",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/944/05/85794405.geojson
+++ b/data/857/944/05/85794405.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Terenure"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f2f07c0d3189f357817c79f652676758",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716584,
+    "wof:lastmodified":1582317587,
     "wof:name":"Terenure",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/944/13/85794413.geojson
+++ b/data/857/944/13/85794413.geojson
@@ -99,6 +99,9 @@
         "wk:page":"Walkinstown"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4f089b3a3f3d265b0309d50de4af2348",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716584,
+    "wof:lastmodified":1582317587,
     "wof:name":"Walkinstown",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/944/25/85794425.geojson
+++ b/data/857/944/25/85794425.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Windy Arbour"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"db32b1de30832019a58ea7612c587de5",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716584,
+    "wof:lastmodified":1582317587,
     "wof:name":"Windy Arbour",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/858/662/31/85866231.geojson
+++ b/data/858/662/31/85866231.geojson
@@ -94,6 +94,10 @@
         "wk:page":"Leopardstown"
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"193057433f69b44df7c6e2308d5f638c",
     "wof:hierarchy":[
         {
@@ -108,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716602,
+    "wof:lastmodified":1582317604,
     "wof:name":"Leopardstown",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/37/85903737.geojson
+++ b/data/859/037/37/85903737.geojson
@@ -87,6 +87,9 @@
         "qs_pg:id":279839
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d5d467c478e4f01bd4bd1034ac8294d2",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716581,
+    "wof:lastmodified":1582317586,
     "wof:name":"\u2018Abb\u0101s\u0101b\u0101d",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/39/85903739.geojson
+++ b/data/859/037/39/85903739.geojson
@@ -114,6 +114,9 @@
         "qs_pg:id":41373
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ca9af55d1c127bfca2b888456bd7765d",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716581,
+    "wof:lastmodified":1582317586,
     "wof:name":"D\u0101v\u016bd\u012byeh",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/41/85903741.geojson
+++ b/data/859/037/41/85903741.geojson
@@ -83,6 +83,9 @@
         "qs:id":1045857
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec7f3da0d7f7be3d89bfa5c1d73c484e",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379347,
+    "wof:lastmodified":1582317586,
     "wof:name":"F\u012bsher\u0101b\u0101d",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/43/85903743.geojson
+++ b/data/859/037/43/85903743.geojson
@@ -85,6 +85,9 @@
         "qs:id":1117334
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e0b1821d95aa381171068f012190cd03",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379347,
+    "wof:lastmodified":1582317586,
     "wof:name":"Jamsh\u012bd\u012byeh",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/45/85903745.geojson
+++ b/data/859/037/45/85903745.geojson
@@ -87,6 +87,9 @@
         "qs:id":318051
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e6f8a394cf466dc816c9db39eb5efef6",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379347,
+    "wof:lastmodified":1582317586,
     "wof:name":"Qa\u015fr-e Q\u0101j\u0101r",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/47/85903747.geojson
+++ b/data/859/037/47/85903747.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":902804
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"551fa21817b8ec19c2719601bb4ead84",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716581,
+    "wof:lastmodified":1582317586,
     "wof:name":"Raj\u0101'\u012bshahr",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/51/85903751.geojson
+++ b/data/859/037/51/85903751.geojson
@@ -83,6 +83,9 @@
         "qs_pg:id":1183226
     },
     "wof:country":"IR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"61b296078e0fd80c98345ac65360c0ec",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566716581,
+    "wof:lastmodified":1582317586,
     "wof:name":"Y\u00f8sef\u00e5b\u00e5d",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.