### PR TITLE
WIP: Move centroids inside geometries

### DIFF
--- a/data/857/943/15/85794315.geojson
+++ b/data/857/943/15/85794315.geojson
@@ -12,8 +12,8 @@
     "gn:latitude":53.31877,
     "gn:longitude":-6.28555,
     "iso:country":"IE",
-    "lbl:latitude":53.320042,
-    "lbl:longitude":-6.290563,
+    "lbl:latitude":53.326825,
+    "lbl:longitude":-6.282711,
     "lbl:max_zoom":18.0,
     "mps:latitude":53.326825,
     "mps:longitude":-6.282711,
@@ -84,7 +84,7 @@
     "src:geom_alt":[
         "quattroshapes_pg"
     ],
-    "src:lbl_centroid":"mz",
+    "src:lbl_centroid":"mapshaper",
     "wd:latitude":53.316667,
     "wd:longitude":-6.288889,
     "wd:wordcount":1624,
@@ -122,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1690934413,
+    "wof:lastmodified":1694320497,
     "wof:name":"Kimmage",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",

--- a/data/857/944/25/85794425.geojson
+++ b/data/857/944/25/85794425.geojson
@@ -12,8 +12,8 @@
     "gn:latitude":53.30431,
     "gn:longitude":-6.24925,
     "iso:country":"IE",
-    "lbl:latitude":53.30069,
-    "lbl:longitude":-6.247052,
+    "lbl:latitude":53.303641,
+    "lbl:longitude":-6.241454,
     "lbl:max_zoom":18.0,
     "mps:latitude":53.303641,
     "mps:longitude":-6.241454,
@@ -76,7 +76,7 @@
     "src:geom_alt":[
         "quattroshapes_pg"
     ],
-    "src:lbl_centroid":"mz",
+    "src:lbl_centroid":"mapshaper",
     "wd:latitude":53.3,
     "wd:longitude":-6.25,
     "wd:wordcount":303,
@@ -112,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1690934410,
+    "wof:lastmodified":1694320497,
     "wof:name":"Windy Arbour",
     "wof:parent_id":101751737,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2159.

This PR updates records with label centroids that fall outside of a geometry. The new label centroid comes from Mapshaper, the `src:lbl_centroid` property has been updated, too.

This PR will require PIP work before merge.