### PR TITLE
ir concordances, placetype local, and more

### DIFF
--- a/data/110/871/977/7/1108719777.geojson
+++ b/data/110/871/977/7/1108719777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.2123,
-    "geom:area_square_m":2268696238.892909,
+    "geom:area_square_m":2268696334.154523,
     "geom:bbox":"48.201329,29.945444,48.947945,30.505404",
     "geom:latitude":30.205735,
     "geom:longitude":48.599398,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120632,
-    "wof:geomhash":"500e2f39524d3508308e19b364ec5617",
+    "wof:geomhash":"e3cc185bd0caaa3dc22c3cab601abba6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719777,
-    "wof:lastmodified":1627522213,
+    "wof:lastmodified":1695886690,
     "wof:name":"Abadan",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/871/977/9/1108719779.geojson
+++ b/data/110/871/977/9/1108719779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.535412,
-    "geom:area_square_m":5659387719.914337,
+    "geom:area_square_m":5659387719.913866,
     "geom:bbox":"51.9348855941,30.7745322241,53.2416670115,31.6703072255",
     "geom:latitude":31.258294,
     "geom:longitude":52.512238,
@@ -177,9 +177,10 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120634,
-    "wof:geomhash":"97539d0fdcb24aa0557d82dcbda92bda",
+    "wof:geomhash":"058b84af7e2ca9804d1a9b2883bf19c3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -189,7 +190,7 @@
         }
     ],
     "wof:id":1108719779,
-    "wof:lastmodified":1566718609,
+    "wof:lastmodified":1695886133,
     "wof:name":"Abadeh",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/871/978/1/1108719781.geojson
+++ b/data/110/871/978/1/1108719781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.50701,
-    "geom:area_square_m":5368698739.90028,
+    "geom:area_square_m":5368698346.168492,
     "geom:bbox":"52.808204,30.658383,54.002572,31.585512",
     "geom:latitude":31.090138,
     "geom:longitude":53.385828,
@@ -148,9 +148,10 @@
         "hasc:id":"IR.YA.AB",
         "wd:id":"Q1286513"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120635,
-    "wof:geomhash":"9742a781b63c80d081e368dd1b292577",
+    "wof:geomhash":"14b3784857581f28cf10633d14d567e5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1108719781,
-    "wof:lastmodified":1690934540,
+    "wof:lastmodified":1695886134,
     "wof:name":"Abarkuh",
     "wof:parent_id":85672317,
     "wof:placetype":"county",

--- a/data/110/871/978/5/1108719785.geojson
+++ b/data/110/871/978/5/1108719785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.230317,
-    "geom:area_square_m":2392569899.295172,
+    "geom:area_square_m":2392569899.295181,
     "geom:bbox":"47.0376185099,32.5150636646,48.0116693082,33.1905234093",
     "geom:latitude":32.847798,
     "geom:longitude":47.545016,
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"IR.IL.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120637,
-    "wof:geomhash":"050f70990c11adf20230f0a32216f813",
+    "wof:geomhash":"3b9e2a19de5918110868c22c6486a3c9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108719785,
-    "wof:lastmodified":1566718611,
+    "wof:lastmodified":1695886134,
     "wof:name":"Abdanan",
     "wof:parent_id":85672333,
     "wof:placetype":"county",

--- a/data/110/871/978/7/1108719787.geojson
+++ b/data/110/871/978/7/1108719787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.28851,
-    "geom:area_square_m":2875795557.524969,
+    "geom:area_square_m":2875795088.253788,
     "geom:bbox":"48.558726,35.878889,49.432129,36.707577",
     "geom:latitude":36.281513,
     "geom:longitude":49.027718,
@@ -145,9 +145,10 @@
         "hasc:id":"IR.ZA.AB",
         "wd:id":"Q374413"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120638,
-    "wof:geomhash":"9a31484e93478f6ccc0416a49e4d974c",
+    "wof:geomhash":"cd4840655b8719368d144f99cd0c49ac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108719787,
-    "wof:lastmodified":1690934540,
+    "wof:lastmodified":1695886133,
     "wof:name":"Abhar",
     "wof:parent_id":85672361,
     "wof:placetype":"county",

--- a/data/110/871/978/9/1108719789.geojson
+++ b/data/110/871/978/9/1108719789.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.14362,
-    "geom:area_square_m":1434902913.887228,
+    "geom:area_square_m":1434902913.887136,
     "geom:bbox":"50.0508157639,35.8432711685,50.6752371474,36.353303033",
     "geom:latitude":36.099558,
     "geom:longitude":50.338256,
@@ -120,9 +120,10 @@
     "wof:concordances":{
         "hasc:id":"IR.QZ.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120639,
-    "wof:geomhash":"dba787eee07fa603090e24756b3acd6f",
+    "wof:geomhash":"05d3a270630e1fedfa83cb2e01c668a1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108719789,
-    "wof:lastmodified":1566718610,
+    "wof:lastmodified":1695886134,
     "wof:name":"Abyek",
     "wof:parent_id":85672367,
     "wof:placetype":"county",

--- a/data/110/871/979/1/1108719791.geojson
+++ b/data/110/871/979/1/1108719791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.319146,
-    "geom:area_square_m":3083105820.805941,
+    "geom:area_square_m":3083105778.75384,
     "geom:bbox":"46.744853,38.305307,47.59642,39.085892",
     "geom:latitude":38.623199,
     "geom:longitude":47.20766,
@@ -153,9 +153,10 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.AH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120640,
-    "wof:geomhash":"e165bc91ad6064d39d6be5c088655bba",
+    "wof:geomhash":"172f0c64b902d4822be5fbfc5b10ccec",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":1108719791,
-    "wof:lastmodified":1636495418,
+    "wof:lastmodified":1695886652,
     "wof:name":"Ahar",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/871/979/3/1108719793.geojson
+++ b/data/110/871/979/3/1108719793.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.781292,
-    "geom:area_square_m":8256348674.034337,
+    "geom:area_square_m":8256348674.03425,
     "geom:bbox":"48.0297669298,30.8901861823,49.308938423,31.7682334799",
     "geom:latitude":31.281435,
     "geom:longitude":48.710022,
@@ -264,9 +264,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.AH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120641,
-    "wof:geomhash":"92c115e93b91723309f07bb51e2fe2ac",
+    "wof:geomhash":"50a64bc14bc30d33cd30a6c7649db1ab",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -276,7 +277,7 @@
         }
     ],
     "wof:id":1108719793,
-    "wof:lastmodified":1566718610,
+    "wof:lastmodified":1695886134,
     "wof:name":"Ahvaz",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/871/979/5/1108719795.geojson
+++ b/data/110/871/979/5/1108719795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072228,
-    "geom:area_square_m":708078471.364294,
+    "geom:area_square_m":708078607.162494,
     "geom:bbox":"45.710862,37.384967,46.33153,37.704844",
     "geom:latitude":37.550435,
     "geom:longitude":46.029723,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.AJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120648,
-    "wof:geomhash":"b3e3c2ab25d5436cf679228cd3ff3723",
+    "wof:geomhash":"a9375f1e862680db0013eea5169b2ff5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719795,
-    "wof:lastmodified":1627522213,
+    "wof:lastmodified":1695886690,
     "wof:name":"Ajabshir",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/871/979/7/1108719797.geojson
+++ b/data/110/871/979/7/1108719797.geojson
@@ -233,6 +233,7 @@
     "wof:concordances":{
         "hasc:id":"IR.QZ.QZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120649,
     "wof:geomhash":"a8a471930f06fe4fdc5fcb112159ed2a",
@@ -245,7 +246,7 @@
         }
     ],
     "wof:id":1108719797,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886134,
     "wof:name":"Alborz",
     "wof:parent_id":85672367,
     "wof:placetype":"county",

--- a/data/110/871/979/9/1108719799.geojson
+++ b/data/110/871/979/9/1108719799.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.112876,
-    "geom:area_square_m":1117010986.605496,
+    "geom:area_square_m":1117010784.879971,
     "geom:bbox":"54.683988,36.600704,55.126267,37.091033",
     "geom:latitude":36.840589,
     "geom:longitude":54.854549,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GO.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120650,
-    "wof:geomhash":"5d5a4a82e952fe3ee5f56df6acff548c",
+    "wof:geomhash":"a51bbcdeb548c4f2b9e4824e0c588f6d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108719799,
-    "wof:lastmodified":1627522213,
+    "wof:lastmodified":1695886690,
     "wof:name":"Aliabad",
     "wof:parent_id":85672299,
     "wof:placetype":"county",

--- a/data/110/871/980/3/1108719803.geojson
+++ b/data/110/871/980/3/1108719803.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.514795,
-    "geom:area_square_m":5330935210.872253,
+    "geom:area_square_m":5330935210.872565,
     "geom:bbox":"48.8326264485,32.7230394453,50.0193193686,33.5649081038",
     "geom:latitude":33.125969,
     "geom:longitude":49.415425,
@@ -120,9 +120,10 @@
     "wof:concordances":{
         "hasc:id":"IR.LO.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120651,
-    "wof:geomhash":"3c0111b20cdb002d03cf11633d04d987",
+    "wof:geomhash":"31270de26664a62a7ac2ac96311d620f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108719803,
-    "wof:lastmodified":1566718615,
+    "wof:lastmodified":1695886136,
     "wof:name":"Aligudarz",
     "wof:parent_id":85672329,
     "wof:placetype":"county",

--- a/data/110/871/980/5/1108719805.geojson
+++ b/data/110/871/980/5/1108719805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041577,
-    "geom:area_square_m":410773558.625088,
+    "geom:area_square_m":410773692.22823,
     "geom:bbox":"50.01548,36.789969,50.267979,37.128099",
     "geom:latitude":36.964959,
     "geom:longitude":50.137966,
@@ -148,9 +148,10 @@
         "hasc:id":"IR.GI.AM",
         "wd:id":"Q1286046"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120653,
-    "wof:geomhash":"7a859e6fab75a3d1217d901e1af87915",
+    "wof:geomhash":"9d0412852d1e4d9cc123725aab2b01cc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1108719805,
-    "wof:lastmodified":1690934541,
+    "wof:lastmodified":1695886136,
     "wof:name":"Amlash",
     "wof:parent_id":85672383,
     "wof:placetype":"county",

--- a/data/110/871/980/7/1108719807.geojson
+++ b/data/110/871/980/7/1108719807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.321343,
-    "geom:area_square_m":3209983313.519645,
+    "geom:area_square_m":3209983624.074463,
     "geom:bbox":"51.737006,35.757821,52.532447,36.629246",
     "geom:latitude":36.112683,
     "geom:longitude":52.243855,
@@ -249,9 +249,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MN.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120654,
-    "wof:geomhash":"748100db059dee4579593d2554df3a91",
+    "wof:geomhash":"8360ddccdecf0c1a235c0f4f8be96115",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -261,7 +262,7 @@
         }
     ],
     "wof:id":1108719807,
-    "wof:lastmodified":1636495419,
+    "wof:lastmodified":1695886653,
     "wof:name":"Amol",
     "wof:parent_id":85672303,
     "wof:placetype":"county",

--- a/data/110/871/980/9/1108719809.geojson
+++ b/data/110/871/980/9/1108719809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.423004,
-    "geom:area_square_m":4601828433.139318,
+    "geom:area_square_m":4601828795.968956,
     "geom:bbox":"57.427524,28.104618,58.621626,28.756465",
     "geom:latitude":28.381177,
     "geom:longitude":58.01088,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KE.AN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120655,
-    "wof:geomhash":"b0fd81cbfe17bb4d44511e29397db8f2",
+    "wof:geomhash":"a7ef849dbfc4181feb01572c0c34efe7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108719809,
-    "wof:lastmodified":1627522213,
+    "wof:lastmodified":1695886690,
     "wof:name":"Anbarabad",
     "wof:parent_id":85672409,
     "wof:placetype":"county",

--- a/data/110/871/981/1/1108719811.geojson
+++ b/data/110/871/981/1/1108719811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.302952,
-    "geom:area_square_m":3152404399.680654,
+    "geom:area_square_m":3152404399.680755,
     "geom:bbox":"47.9030714147,32.2757150168,48.7777499901,32.9974619588",
     "geom:latitude":32.698159,
     "geom:longitude":48.328885,
@@ -132,9 +132,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.AN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120656,
-    "wof:geomhash":"f4be64e58c7fe47d255d9039fd441933",
+    "wof:geomhash":"e468d99e2a17961925c38cb167f53682",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108719811,
-    "wof:lastmodified":1566718616,
+    "wof:lastmodified":1695886136,
     "wof:name":"Andimeshk",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/871/981/3/1108719813.geojson
+++ b/data/110/871/981/3/1108719813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.187214,
-    "geom:area_square_m":1844809051.10212,
+    "geom:area_square_m":1844809072.884281,
     "geom:bbox":"54.228736,36.915482,54.859479,37.451017",
     "geom:latitude":37.163446,
     "geom:longitude":54.528939,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GO.AQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120657,
-    "wof:geomhash":"fc33e9f2b366a9b705715d41195c3378",
+    "wof:geomhash":"21bb5f0148975ea13ad94590f55915e3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719813,
-    "wof:lastmodified":1627522214,
+    "wof:lastmodified":1695886690,
     "wof:name":"Aq Qala",
     "wof:parent_id":85672299,
     "wof:placetype":"county",

--- a/data/110/871/981/5/1108719815.geojson
+++ b/data/110/871/981/5/1108719815.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.598623,
-    "geom:area_square_m":6123949383.638538,
+    "geom:area_square_m":6123949448.478373,
     "geom:bbox":"51.299811,33.792317,52.427057,34.510005",
     "geom:latitude":34.174559,
     "geom:longitude":51.874464,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120658,
-    "wof:geomhash":"ef7607e37d31bf87fbb7b7a296841e8c",
+    "wof:geomhash":"dd8a84b75d42e4f3c37d836d35cef4eb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719815,
-    "wof:lastmodified":1627522214,
+    "wof:lastmodified":1695886690,
     "wof:name":"Aran and Bidgol",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/871/981/7/1108719817.geojson
+++ b/data/110/871/981/7/1108719817.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.222572,
-    "geom:area_square_m":23150836067.833145,
+    "geom:area_square_m":23150836067.832947,
     "geom:bbox":"53.012380346,32.0408403078,56.3031031542,33.3651814253",
     "geom:latitude":32.606293,
     "geom:longitude":54.767405,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"IR.YA.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120660,
-    "wof:geomhash":"79dbfbe521f914336e7739d4d5a4ae28",
+    "wof:geomhash":"a4b54dee4f71ee3904a324ceae355058",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108719817,
-    "wof:lastmodified":1566718616,
+    "wof:lastmodified":1695886136,
     "wof:name":"Ardakan",
     "wof:parent_id":85672317,
     "wof:placetype":"county",

--- a/data/110/871/982/1/1108719821.geojson
+++ b/data/110/871/982/1/1108719821.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.17715,
-    "geom:area_square_m":1859399246.640489,
+    "geom:area_square_m":1859398665.116139,
     "geom:bbox":"50.151239,31.592498,50.734234,32.234835",
     "geom:latitude":31.912834,
     "geom:longitude":50.458833,
@@ -108,9 +108,10 @@
     "wof:concordances":{
         "hasc:id":"IR.CM.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120661,
-    "wof:geomhash":"40bfcc2c3236b3d189c6926dad1c407c",
+    "wof:geomhash":"3ff6c434657df140d8eb319fbeadcd74",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108719821,
-    "wof:lastmodified":1627522214,
+    "wof:lastmodified":1695886690,
     "wof:name":"Ardal",
     "wof:parent_id":85672319,
     "wof:placetype":"county",

--- a/data/110/871/982/3/1108719823.geojson
+++ b/data/110/871/982/3/1108719823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.265328,
-    "geom:area_square_m":2576379757.32567,
+    "geom:area_square_m":2576379988.486101,
     "geom:bbox":"47.78643,37.931914,48.682187,38.645114",
     "geom:latitude":38.252865,
     "geom:longitude":48.231382,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.AR.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120662,
-    "wof:geomhash":"0e8d9493b309745becd04f52266e7ca9",
+    "wof:geomhash":"cab20b14a445b2c3870476a9dfd500e6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719823,
-    "wof:lastmodified":1627522214,
+    "wof:lastmodified":1695886690,
     "wof:name":"Ardebil",
     "wof:parent_id":85672343,
     "wof:placetype":"county",

--- a/data/110/871/982/5/1108719825.geojson
+++ b/data/110/871/982/5/1108719825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.219102,
-    "geom:area_square_m":12556554655.637526,
+    "geom:area_square_m":12556554655.637163,
     "geom:bbox":"51.825834058,32.872858982,53.2177076036,34.4259608869",
     "geom:latitude":33.593039,
     "geom:longitude":52.613621,
@@ -108,9 +108,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120663,
-    "wof:geomhash":"1ca649492ddfe67c0e8f14d35c7deb57",
+    "wof:geomhash":"06c7dcf129f07a2d5ff4f7db43631ff8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108719825,
-    "wof:lastmodified":1566718612,
+    "wof:lastmodified":1695886134,
     "wof:name":"Ardestan",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/871/982/7/1108719827.geojson
+++ b/data/110/871/982/7/1108719827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134841,
-    "geom:area_square_m":1446377340.537099,
+    "geom:area_square_m":1446377406.649427,
     "geom:bbox":"53.124185,29.649283,53.737324,30.019675",
     "geom:latitude":29.832603,
     "geom:longitude":53.38574,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120664,
-    "wof:geomhash":"113e02c156b605b3f61932afa79fa7a2",
+    "wof:geomhash":"89e73c94028cd808f0b1084bdd178071",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108719827,
-    "wof:lastmodified":1627522214,
+    "wof:lastmodified":1695886690,
     "wof:name":"Arsanjan",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/871/982/9/1108719829.geojson
+++ b/data/110/871/982/9/1108719829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.11404,
-    "geom:area_square_m":1158197800.340623,
+    "geom:area_square_m":1158198029.9259,
     "geom:bbox":"47.801236,34.58857,48.267157,34.984798",
     "geom:latitude":34.780626,
     "geom:longitude":48.029105,
@@ -108,9 +108,10 @@
     "wof:concordances":{
         "hasc:id":"IR.HD.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120666,
-    "wof:geomhash":"9a2018e63e0984def0a49fb6a0c4dd3f",
+    "wof:geomhash":"4ab5242d592d76ccf7ecde7c3d9332ba",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108719829,
-    "wof:lastmodified":1636495419,
+    "wof:lastmodified":1695886653,
     "wof:name":"Asadabad",
     "wof:parent_id":85672355,
     "wof:placetype":"county",

--- a/data/110/871/983/1/1108719831.geojson
+++ b/data/110/871/983/1/1108719831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.120976,
-    "geom:area_square_m":1233772071.874417,
+    "geom:area_square_m":1233772071.87443,
     "geom:bbox":"49.7593091944,34.2609398472,50.3615705041,34.6211671994",
     "geom:latitude":34.434505,
     "geom:longitude":50.050044,
@@ -108,9 +108,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MK.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120667,
-    "wof:geomhash":"636739b7ff4b82f6b73de118f74b3865",
+    "wof:geomhash":"30c75d1a8af5fb2451cecd6af718702f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108719831,
-    "wof:lastmodified":1566718609,
+    "wof:lastmodified":1695886133,
     "wof:name":"Ashtian",
     "wof:parent_id":85672347,
     "wof:placetype":"county",

--- a/data/110/871/983/3/1108719833.geojson
+++ b/data/110/871/983/3/1108719833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041925,
-    "geom:area_square_m":412200377.439104,
+    "geom:area_square_m":412200374.541152,
     "geom:bbox":"49.77488,37.202902,50.181697,37.467278",
     "geom:latitude":37.332698,
     "geom:longitude":49.986259,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GI.AA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120668,
-    "wof:geomhash":"72e670d166d88669ec9dddde649b4bef",
+    "wof:geomhash":"e5568442d825f5532d6d35e0f18068e0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719833,
-    "wof:lastmodified":1627522214,
+    "wof:lastmodified":1695886690,
     "wof:name":"Astane-ye-Ashrafiyeh",
     "wof:parent_id":85672383,
     "wof:placetype":"county",

--- a/data/110/871/983/5/1108719835.geojson
+++ b/data/110/871/983/5/1108719835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043325,
-    "geom:area_square_m":420128247.522019,
+    "geom:area_square_m":420128403.313404,
     "geom:bbox":"48.569675,38.241041,48.879723,38.451999",
     "geom:latitude":38.350747,
     "geom:longitude":48.739273,
@@ -126,9 +126,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GI.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120669,
-    "wof:geomhash":"a7ef72e8da89da0a4d3957cd9b73de82",
+    "wof:geomhash":"b8089490dfafaa54ae9655153633f6cf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108719835,
-    "wof:lastmodified":1636495418,
+    "wof:lastmodified":1695886653,
     "wof:name":"Astara",
     "wof:parent_id":85672383,
     "wof:placetype":"county",

--- a/data/110/871/983/9/1108719839.geojson
+++ b/data/110/871/983/9/1108719839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086855,
-    "geom:area_square_m":857837643.147797,
+    "geom:area_square_m":857838095.953756,
     "geom:bbox":"55.058771,36.798993,55.605398,37.191662",
     "geom:latitude":36.989061,
     "geom:longitude":55.340842,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GO.AZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120670,
-    "wof:geomhash":"ed9796df3b0ceaf5f245c5194cf5028d",
+    "wof:geomhash":"7896d50316aef39ac355d081df2a8cfa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108719839,
-    "wof:lastmodified":1627522214,
+    "wof:lastmodified":1695886690,
     "wof:name":"Azadshahr",
     "wof:parent_id":85672299,
     "wof:placetype":"county",

--- a/data/110/871/984/1/1108719841.geojson
+++ b/data/110/871/984/1/1108719841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.107362,
-    "geom:area_square_m":1049975162.291464,
+    "geom:area_square_m":1049975029.795676,
     "geom:bbox":"45.655685,37.564805,46.165704,37.894229",
     "geom:latitude":37.729495,
     "geom:longitude":45.903625,
@@ -114,9 +114,10 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.AZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120671,
-    "wof:geomhash":"e142b0feb61b0bd02a36c7d128f5c29c",
+    "wof:geomhash":"378980fb3d97bb1fa08be1e2dc6ce49a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108719841,
-    "wof:lastmodified":1627522214,
+    "wof:lastmodified":1695886691,
     "wof:name":"Azarshahr",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/871/984/3/1108719843.geojson
+++ b/data/110/871/984/3/1108719843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.135541,
-    "geom:area_square_m":1397454839.565437,
+    "geom:area_square_m":1397454911.509462,
     "geom:bbox":"49.226312,33.234948,49.717181,33.749931",
     "geom:latitude":33.507795,
     "geom:longitude":49.442304,
@@ -148,9 +148,10 @@
         "hasc:id":"IR.LO.AZ",
         "wd:id":"Q666797"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120673,
-    "wof:geomhash":"0cb4ac90b2b41dfc98be41d9872fc81f",
+    "wof:geomhash":"3d72d188ea1ce26a7d1bc697811b320e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1108719843,
-    "wof:lastmodified":1690934539,
+    "wof:lastmodified":1695886134,
     "wof:name":"Azna",
     "wof:parent_id":85672329,
     "wof:placetype":"county",

--- a/data/110/871/984/5/1108719845.geojson
+++ b/data/110/871/984/5/1108719845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.14963,
-    "geom:area_square_m":1491057812.583641,
+    "geom:area_square_m":1491058072.438772,
     "geom:bbox":"52.474287,35.931195,52.799368,36.615076",
     "geom:latitude":36.303588,
     "geom:longitude":52.623112,
@@ -166,9 +166,10 @@
         "hasc:id":"IR.MN.BL",
         "wd:id":"Q1282212"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120674,
-    "wof:geomhash":"e22258283a601b8fbab54f8d7a8b6a60",
+    "wof:geomhash":"0c98325433125f977cb314a45d4bdd19",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":1108719845,
-    "wof:lastmodified":1690934540,
+    "wof:lastmodified":1695886134,
     "wof:name":"Babol",
     "wof:parent_id":85672303,
     "wof:placetype":"county",

--- a/data/110/871/984/7/1108719847.geojson
+++ b/data/110/871/984/7/1108719847.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036654,
-    "geom:area_square_m":363572563.281833,
+    "geom:area_square_m":363572563.281897,
     "geom:bbox":"52.4729134755,36.5798167722,52.8431213542,36.7461475692",
     "geom:latitude":36.662108,
     "geom:longitude":52.655598,
@@ -114,9 +114,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MN.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120675,
-    "wof:geomhash":"6877c80b063d93971202069b9e3fedc3",
+    "wof:geomhash":"8448351d482a774add5a2c46c297abd7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108719847,
-    "wof:lastmodified":1566718609,
+    "wof:lastmodified":1695886133,
     "wof:name":"Babolsar",
     "wof:parent_id":85672303,
     "wof:placetype":"county",

--- a/data/110/871/984/9/1108719849.geojson
+++ b/data/110/871/984/9/1108719849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.441726,
-    "geom:area_square_m":15147870152.793766,
+    "geom:area_square_m":15147870943.007896,
     "geom:bbox":"54.72124,31.111862,56.653612,32.477466",
     "geom:latitude":31.819368,
     "geom:longitude":55.726772,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.YA.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120676,
-    "wof:geomhash":"50c7ab693e3b6fa5b5c95cb2dd579c95",
+    "wof:geomhash":"c6c58f81312a55e4837a1f4714a1c518",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719849,
-    "wof:lastmodified":1627522214,
+    "wof:lastmodified":1695886691,
     "wof:name":"Bafgh",
     "wof:parent_id":85672317,
     "wof:placetype":"county",

--- a/data/110/871/985/1/1108719851.geojson
+++ b/data/110/871/985/1/1108719851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.192417,
-    "geom:area_square_m":12917440513.542892,
+    "geom:area_square_m":12917440513.542637,
     "geom:bbox":"56.0300222004,28.1305082148,57.2707354244,29.5783758192",
     "geom:latitude":28.82393,
     "geom:longitude":56.569901,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KE.BF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120678,
-    "wof:geomhash":"24c76b21a968e644e5663de1df74198b",
+    "wof:geomhash":"4b02421188493b52aceabe455e02ad25",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108719851,
-    "wof:lastmodified":1566718611,
+    "wof:lastmodified":1695886134,
     "wof:name":"Baft",
     "wof:parent_id":85672409,
     "wof:placetype":"county",

--- a/data/110/871/985/3/1108719853.geojson
+++ b/data/110/871/985/3/1108719853.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120679,
     "wof:geomhash":"f962b9251ef716e8f38ca7f8844a0503",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108719853,
-    "wof:lastmodified":1694498049,
+    "wof:lastmodified":1695886691,
     "wof:name":"Baghmalek",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/871/985/7/1108719857.geojson
+++ b/data/110/871/985/7/1108719857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.129431,
-    "geom:area_square_m":1311230277.400618,
+    "geom:area_square_m":1311230277.400498,
     "geom:bbox":"48.1386210401,34.7523446113,48.688273591,35.162748363",
     "geom:latitude":34.985622,
     "geom:longitude":48.362715,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"IR.HD.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120680,
-    "wof:geomhash":"e2536cd2f3c9fb2803f7f747baa3a079",
+    "wof:geomhash":"1a9eb6037c1f90fc3db2b26b85c54700",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108719857,
-    "wof:lastmodified":1566718611,
+    "wof:lastmodified":1695886134,
     "wof:name":"Bahar",
     "wof:parent_id":85672355,
     "wof:placetype":"county",

--- a/data/110/871/985/9/1108719859.geojson
+++ b/data/110/871/985/9/1108719859.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KB.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120681,
     "wof:geomhash":"69cd54756d309f86bee83eb9f789e038",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108719859,
-    "wof:lastmodified":1694498049,
+    "wof:lastmodified":1695886691,
     "wof:name":"Bahmaee",
     "wof:parent_id":85672283,
     "wof:placetype":"county",

--- a/data/110/871/986/1/1108719861.geojson
+++ b/data/110/871/986/1/1108719861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.788263,
-    "geom:area_square_m":19348431105.794052,
+    "geom:area_square_m":19348431473.014042,
     "geom:bbox":"57.700243,28.078933,59.569391,29.627782",
     "geom:latitude":28.951698,
     "geom:longitude":58.752849,
@@ -105,9 +105,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KE.BM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120682,
-    "wof:geomhash":"ae62d4531ffe04d758e19dee9b87df3e",
+    "wof:geomhash":"054333192ad93c2c2067cba2cf8d9d91",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108719861,
-    "wof:lastmodified":1636495420,
+    "wof:lastmodified":1695886654,
     "wof:name":"Bam",
     "wof:parent_id":85672409,
     "wof:placetype":"county",

--- a/data/110/871/986/3/1108719863.geojson
+++ b/data/110/871/986/3/1108719863.geojson
@@ -221,6 +221,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120684,
     "wof:geomhash":"6afc1fd010f221767e95a5b08d8fc296",
@@ -233,7 +234,7 @@
         }
     ],
     "wof:id":1108719863,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886137,
     "wof:name":"Bandar Abbas",
     "wof:parent_id":85672337,
     "wof:placetype":"county",

--- a/data/110/871/986/5/1108719865.geojson
+++ b/data/110/871/986/5/1108719865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029586,
-    "geom:area_square_m":290387659.769601,
+    "geom:area_square_m":290388914.625398,
     "geom:bbox":"49.197205,37.375513,49.663674,37.568257",
     "geom:latitude":37.460967,
     "geom:longitude":49.408819,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GI.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120685,
-    "wof:geomhash":"0ad209f308d4bcf1dd21a839b1f45856",
+    "wof:geomhash":"66a8f707d0396b0dd8603cc759fbaaba",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719865,
-    "wof:lastmodified":1627522215,
+    "wof:lastmodified":1695886691,
     "wof:name":"Bandar Anzali",
     "wof:parent_id":85672383,
     "wof:placetype":"county",

--- a/data/110/871/986/7/1108719867.geojson
+++ b/data/110/871/986/7/1108719867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02441,
-    "geom:area_square_m":241898546.393578,
+    "geom:area_square_m":241898723.299686,
     "geom:bbox":"53.860808,36.648857,54.06022,36.821646",
     "geom:latitude":36.733723,
     "geom:longitude":53.963995,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GO.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120686,
-    "wof:geomhash":"9213e8de0eea8f6cf8b9f1bf68c418f3",
+    "wof:geomhash":"5474dea5da976c9f37ce05b845a531ca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719867,
-    "wof:lastmodified":1627522215,
+    "wof:lastmodified":1695886691,
     "wof:name":"Bandar Gaz",
     "wof:parent_id":85672299,
     "wof:placetype":"county",

--- a/data/110/871/986/9/1108719869.geojson
+++ b/data/110/871/986/9/1108719869.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.700025,
-    "geom:area_square_m":7723682016.664298,
+    "geom:area_square_m":7723682016.664268,
     "geom:bbox":"53.157054901,26.494556427,55.587081909,27.1325893018",
     "geom:latitude":26.83629,
     "geom:longitude":54.605209,
@@ -117,9 +117,10 @@
     "wof:concordances":{
         "hasc:id":"IR.HG.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120687,
-    "wof:geomhash":"cba07e2d9fbdb27e19ec4bfb03d33309",
+    "wof:geomhash":"4196f12dd6c74d5e251e4599b3294259",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108719869,
-    "wof:lastmodified":1566718617,
+    "wof:lastmodified":1695886137,
     "wof:name":"Bandar Lengeh",
     "wof:parent_id":85672337,
     "wof:placetype":"county",

--- a/data/110/871/987/1/1108719871.geojson
+++ b/data/110/871/987/1/1108719871.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.146608,
-    "geom:area_square_m":1559128380.886216,
+    "geom:area_square_m":1559128047.062282,
     "geom:bbox":"48.920065,30.421223,49.358618,30.929228",
     "geom:latitude":30.677912,
     "geom:longitude":49.134754,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.BM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120688,
-    "wof:geomhash":"fe8b5ced374fe944cd0a60a6c016192b",
+    "wof:geomhash":"99d9c32213e3255fab21844cf7ff35cb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719871,
-    "wof:lastmodified":1627522215,
+    "wof:lastmodified":1695886691,
     "wof:name":"Bandar-e-Mahshahr",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/871/987/5/1108719875.geojson
+++ b/data/110/871/987/5/1108719875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.155312,
-    "geom:area_square_m":1553737142.040611,
+    "geom:area_square_m":1553737142.040485,
     "geom:bbox":"45.5510365807,35.799014,46.195381682,36.2391952897",
     "geom:latitude":35.997443,
     "geom:longitude":45.849129,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KD.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120690,
-    "wof:geomhash":"28882a9efb7149fbacc5b7a40cd00776",
+    "wof:geomhash":"9304b70d273dae783d9e6d0a55cd5141",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108719875,
-    "wof:lastmodified":1566718614,
+    "wof:lastmodified":1695886135,
     "wof:name":"Baneh",
     "wof:parent_id":85672387,
     "wof:placetype":"county",

--- a/data/110/871/987/7/1108719877.geojson
+++ b/data/110/871/987/7/1108719877.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.750864,
-    "geom:area_square_m":7587996771.005347,
+    "geom:area_square_m":7587995886.835785,
     "geom:bbox":"56.229356,34.682114,58.247966,35.587357",
     "geom:latitude":35.187114,
     "geom:longitude":57.340372,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120691,
-    "wof:geomhash":"ca29cc043f66e15d4c68ce9d849df6fa",
+    "wof:geomhash":"d0467cdfd744301162b3916e3ef2933b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719877,
-    "wof:lastmodified":1627522215,
+    "wof:lastmodified":1695886691,
     "wof:name":"Bardeskan",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/871/987/9/1108719879.geojson
+++ b/data/110/871/987/9/1108719879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.569589,
-    "geom:area_square_m":6113202459.624702,
+    "geom:area_square_m":6113202793.281538,
     "geom:bbox":"56.003509,29.388354,57.312945,30.198198",
     "geom:latitude":29.775485,
     "geom:longitude":56.694293,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KE.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120693,
-    "wof:geomhash":"d2fcf8eca3b69924f12a4b63f4031591",
+    "wof:geomhash":"eb1fc2ad1807046fb38bf55fbe8f77f0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108719879,
-    "wof:lastmodified":1627522215,
+    "wof:lastmodified":1695886691,
     "wof:name":"Bardsir",
     "wof:parent_id":85672409,
     "wof:placetype":"county",

--- a/data/110/871/988/1/1108719881.geojson
+++ b/data/110/871/988/1/1108719881.geojson
@@ -95,6 +95,7 @@
     "wof:concordances":{
         "hasc:id":"IR.HG.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120694,
     "wof:geomhash":"fc12a25433d10726be6ac547dd892b51",
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108719881,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886136,
     "wof:name":"Bastak",
     "wof:parent_id":85672337,
     "wof:placetype":"county",

--- a/data/110/871/988/3/1108719883.geojson
+++ b/data/110/871/988/3/1108719883.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120695,
     "wof:geomhash":"c79c10d8ff37473308a9b7afbf6544c6",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108719883,
-    "wof:lastmodified":1694498049,
+    "wof:lastmodified":1695886691,
     "wof:name":"Bavanat",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/871/988/5/1108719885.geojson
+++ b/data/110/871/988/5/1108719885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.277748,
-    "geom:area_square_m":2958248575.489108,
+    "geom:area_square_m":2958248575.488945,
     "geom:bbox":"49.7941389474,30.1651325062,50.550828069,30.9024322152",
     "geom:latitude":30.530549,
     "geom:longitude":50.211319,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120697,
-    "wof:geomhash":"12d863028bbd2fcb56913a0bc9159105",
+    "wof:geomhash":"6a2f5fc06dccedad9ebd0a713ad787b4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108719885,
-    "wof:lastmodified":1566718616,
+    "wof:lastmodified":1695886137,
     "wof:name":"Behbahan",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/871/988/7/1108719887.geojson
+++ b/data/110/871/988/7/1108719887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.153241,
-    "geom:area_square_m":1519647500.122073,
+    "geom:area_square_m":1519647500.122,
     "geom:bbox":"53.2699588147,36.4493921256,54.1305346162,36.947498322",
     "geom:latitude":36.679702,
     "geom:longitude":53.68419,
@@ -132,9 +132,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MN.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120698,
-    "wof:geomhash":"0a14f2b86228168f6409c113ddf70cc6",
+    "wof:geomhash":"535fd21b29b1f3dd9c7e615f80cc6165",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108719887,
-    "wof:lastmodified":1566718616,
+    "wof:lastmodified":1695886137,
     "wof:name":"Behshahr",
     "wof:parent_id":85672303,
     "wof:placetype":"county",

--- a/data/110/871/988/9/1108719889.geojson
+++ b/data/110/871/988/9/1108719889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.588909,
-    "geom:area_square_m":5895350319.794121,
+    "geom:area_square_m":5895350319.568543,
     "geom:bbox":"47.08352,35.497173,48.248984,36.434026",
     "geom:latitude":35.944265,
     "geom:longitude":47.645604,
@@ -163,9 +163,10 @@
         "hasc:id":"IR.KD.BI",
         "wd:id":"Q1282103"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120699,
-    "wof:geomhash":"69d1683bada90ab631a425b3fb73058f",
+    "wof:geomhash":"eaea30980226558cf3404786619043a9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":1108719889,
-    "wof:lastmodified":1690934542,
+    "wof:lastmodified":1695886654,
     "wof:name":"Bijar",
     "wof:parent_id":85672387,
     "wof:placetype":"county",

--- a/data/110/871/989/3/1108719893.geojson
+++ b/data/110/871/989/3/1108719893.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.187987,
-    "geom:area_square_m":1797657446.751585,
+    "geom:area_square_m":1797657293.481871,
     "geom:bbox":"47.61542,39.12683,48.368427,39.566799",
     "geom:latitude":39.343806,
     "geom:longitude":47.973228,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.AR.BI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120701,
-    "wof:geomhash":"2b2772351643a6c409a80c6d5a3920ea",
+    "wof:geomhash":"812de9e51cdc388a340369831ea6a4ca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719893,
-    "wof:lastmodified":1627522215,
+    "wof:lastmodified":1695886691,
     "wof:name":"Bilehsavar",
     "wof:parent_id":85672343,
     "wof:placetype":"county",

--- a/data/110/871/989/5/1108719895.geojson
+++ b/data/110/871/989/5/1108719895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.881275,
-    "geom:area_square_m":19627952515.70219,
+    "geom:area_square_m":19627951123.745255,
     "geom:bbox":"57.995214,31.450043,59.69554,33.501719",
     "geom:latitude":32.456805,
     "geom:longitude":58.807094,
@@ -157,9 +157,10 @@
         "hasc:id":"IR.KJ.BI",
         "wd:id":"Q1286327"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120702,
-    "wof:geomhash":"14e9b778186cbf9e4530a0ee230a8aa5",
+    "wof:geomhash":"81261e6951c79cd2ef536611b105c5e7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -169,7 +170,7 @@
         }
     ],
     "wof:id":1108719895,
-    "wof:lastmodified":1690934542,
+    "wof:lastmodified":1695886653,
     "wof:name":"Birjand",
     "wof:parent_id":85672391,
     "wof:placetype":"county",

--- a/data/110/871/989/7/1108719897.geojson
+++ b/data/110/871/989/7/1108719897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.61509,
-    "geom:area_square_m":6011249898.956744,
+    "geom:area_square_m":6011249925.049107,
     "geom:bbox":"56.318487,37.217752,57.722019,38.286124",
     "geom:latitude":37.779682,
     "geom:longitude":57.162031,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KS.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120703,
-    "wof:geomhash":"dfbae8eec043bd52f0c761028f131b1a",
+    "wof:geomhash":"cf04813c3bf5fe5ff23e31d0c98a7085",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108719897,
-    "wof:lastmodified":1636495419,
+    "wof:lastmodified":1695886653,
     "wof:name":"Bojnurd",
     "wof:parent_id":85672401,
     "wof:placetype":"county",

--- a/data/110/871/989/9/1108719899.geojson
+++ b/data/110/871/989/9/1108719899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068907,
-    "geom:area_square_m":677520726.227849,
+    "geom:area_square_m":677520908.073705,
     "geom:bbox":"45.753171,37.162805,46.201932,37.531644",
     "geom:latitude":37.329075,
     "geom:longitude":46.017395,
@@ -120,9 +120,10 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120705,
-    "wof:geomhash":"3798ecbd463d367734d3df6afc58653e",
+    "wof:geomhash":"62b2319566c1e6fd1b3efdd3958b1039",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108719899,
-    "wof:lastmodified":1627522216,
+    "wof:lastmodified":1695886692,
     "wof:name":"Bonab",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/871/990/1/1108719901.geojson
+++ b/data/110/871/990/1/1108719901.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.674207,
-    "geom:area_square_m":6973880779.583749,
+    "geom:area_square_m":6973881142.570852,
     "geom:bbox":"50.584801,32.738851,52.07337,33.731521",
     "geom:latitude":33.223878,
     "geom:longitude":51.322773,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.BM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120706,
-    "wof:geomhash":"590d6de520c596e7691c89208a73d820",
+    "wof:geomhash":"edd5f420472efa52c7b994454337b421",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719901,
-    "wof:lastmodified":1627522216,
+    "wof:lastmodified":1695886692,
     "wof:name":"Borkhar and Meymeh",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/871/990/3/1108719903.geojson
+++ b/data/110/871/990/3/1108719903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.241061,
-    "geom:area_square_m":2531486993.318094,
+    "geom:area_square_m":2531486993.317651,
     "geom:bbox":"50.7783551044,31.489926541,51.4330338412,32.2230908401",
     "geom:latitude":31.866917,
     "geom:longitude":51.153543,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"IR.CM.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120708,
-    "wof:geomhash":"ebee3a5008d55df639afb6843e3c2032",
+    "wof:geomhash":"8180d09d9744359753ca529a728c9346",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108719903,
-    "wof:lastmodified":1566718608,
+    "wof:lastmodified":1695886133,
     "wof:name":"Borujen",
     "wof:parent_id":85672319,
     "wof:placetype":"county",

--- a/data/110/871/990/5/1108719905.geojson
+++ b/data/110/871/990/5/1108719905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.158043,
-    "geom:area_square_m":1622184998.440186,
+    "geom:area_square_m":1622184976.452136,
     "geom:bbox":"48.472696,33.611571,49.06576,34.123209",
     "geom:latitude":33.891868,
     "geom:longitude":48.756497,
@@ -163,9 +163,10 @@
         "hasc:id":"IR.LO.BO",
         "wd:id":"Q1286028"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120709,
-    "wof:geomhash":"f025a417c722a7d27f6d65ab68b9253b",
+    "wof:geomhash":"98d209ab447e66ff8b76285877f139c9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":1108719905,
-    "wof:lastmodified":1690934539,
+    "wof:lastmodified":1695886653,
     "wof:name":"Borujerd",
     "wof:parent_id":85672329,
     "wof:placetype":"county",

--- a/data/110/871/990/7/1108719907.geojson
+++ b/data/110/871/990/7/1108719907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.279363,
-    "geom:area_square_m":2729326522.17367,
+    "geom:area_square_m":2729327174.389174,
     "geom:bbox":"46.465122,37.539674,47.240784,38.090375",
     "geom:latitude":37.804374,
     "geom:longitude":46.813802,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120710,
-    "wof:geomhash":"7886f3c850b0376b74871cff7f1ee771",
+    "wof:geomhash":"dd7f0f6db5a9189e3a08356194fa4cab",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108719907,
-    "wof:lastmodified":1627522216,
+    "wof:lastmodified":1695886692,
     "wof:name":"Bostanabad",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/871/991/1/1108719911.geojson
+++ b/data/110/871/991/1/1108719911.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.354257,
-    "geom:area_square_m":3761189461.429925,
+    "geom:area_square_m":3761189395.141742,
     "geom:bbox":"50.47963,30.371969,51.888918,31.451869",
     "geom:latitude":30.835883,
     "geom:longitude":51.233952,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KB.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120712,
-    "wof:geomhash":"8f04798235225935fd61f4714b1ef798",
+    "wof:geomhash":"aa060818c096154d880637ecc18c4a24",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719911,
-    "wof:lastmodified":1627522216,
+    "wof:lastmodified":1695886692,
     "wof:name":"Boyerahmad",
     "wof:parent_id":85672283,
     "wof:placetype":"county",

--- a/data/110/871/991/3/1108719913.geojson
+++ b/data/110/871/991/3/1108719913.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.566611,
-    "geom:area_square_m":5687038230.919206,
+    "geom:area_square_m":5687038442.310616,
     "geom:bbox":"48.725448,35.40135,50.314167,36.177974",
     "geom:latitude":35.736447,
     "geom:longitude":49.61109,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.QZ.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120713,
-    "wof:geomhash":"6380390c6721619cf66f423892d2a2da",
+    "wof:geomhash":"1b59b081b1f5bcf77cf2026ab655407b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719913,
-    "wof:lastmodified":1627522216,
+    "wof:lastmodified":1695886692,
     "wof:name":"Boyinzahra",
     "wof:parent_id":85672367,
     "wof:placetype":"county",

--- a/data/110/871/991/5/1108719915.geojson
+++ b/data/110/871/991/5/1108719915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.251102,
-    "geom:area_square_m":2494048869.523485,
+    "geom:area_square_m":2494048934.863147,
     "geom:bbox":"45.698903,36.219274,46.500012,36.867161",
     "geom:latitude":36.557704,
     "geom:longitude":46.139478,
@@ -148,9 +148,10 @@
         "hasc:id":"IR.WA.BU",
         "wd:id":"Q1294493"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120714,
-    "wof:geomhash":"291db6b959f40aa5823bb903a918d75d",
+    "wof:geomhash":"ff6436ebb98dd4e6968309babc002c24",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1108719915,
-    "wof:lastmodified":1690934538,
+    "wof:lastmodified":1695886132,
     "wof:name":"Bukan",
     "wof:parent_id":85672369,
     "wof:placetype":"county",

--- a/data/110/871/991/7/1108719917.geojson
+++ b/data/110/871/991/7/1108719917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.123314,
-    "geom:area_square_m":1332507902.668463,
+    "geom:area_square_m":1332507183.007752,
     "geom:bbox":"50.282055,28.81625,51.209485,29.306146",
     "geom:latitude":29.086303,
     "geom:longitude":50.941142,
@@ -201,9 +201,10 @@
     "wof:concordances":{
         "hasc:id":"IR.BS.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120716,
-    "wof:geomhash":"23d19a3c873a2d39b84163cf62c874a8",
+    "wof:geomhash":"251c46c9e4748739db35103c8ba7865d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -213,7 +214,7 @@
         }
     ],
     "wof:id":1108719917,
-    "wof:lastmodified":1636495418,
+    "wof:lastmodified":1695886653,
     "wof:name":"Bushehr",
     "wof:parent_id":85672289,
     "wof:placetype":"county",

--- a/data/110/871/991/9/1108719919.geojson
+++ b/data/110/871/991/9/1108719919.geojson
@@ -134,6 +134,7 @@
     "wof:concordances":{
         "hasc:id":"IR.SB.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120717,
     "wof:geomhash":"4f4d832f8884f0c058855406dc0d6a89",
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1108719919,
-    "wof:lastmodified":1694498102,
+    "wof:lastmodified":1695886653,
     "wof:name":"Chabahar",
     "wof:parent_id":85672405,
     "wof:placetype":"county",

--- a/data/110/871/992/1/1108719921.geojson
+++ b/data/110/871/992/1/1108719921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.115306,
-    "geom:area_square_m":1199142583.422375,
+    "geom:area_square_m":1199142574.581213,
     "geom:bbox":"50.22346,32.537121,50.853284,32.962828",
     "geom:latitude":32.749662,
     "geom:longitude":50.53121,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120718,
-    "wof:geomhash":"96c5a91f5c7c12db574995d66ca460b6",
+    "wof:geomhash":"1ed2264353e4d6afa2f4c047457539e5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108719921,
-    "wof:lastmodified":1627522216,
+    "wof:lastmodified":1695886692,
     "wof:name":"Chadegan",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/871/992/3/1108719923.geojson
+++ b/data/110/871/992/3/1108719923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.206411,
-    "geom:area_square_m":1980751164.106637,
+    "geom:area_square_m":1980750787.169896,
     "geom:bbox":"44.031891,38.785608,44.782629,39.417803",
     "geom:latitude":39.098492,
     "geom:longitude":44.373509,
@@ -145,9 +145,10 @@
         "hasc:id":"IR.WA.CH",
         "wd:id":"Q1180764"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120719,
-    "wof:geomhash":"e7c2c938b5b20befd16aa6e17bd7cfb7",
+    "wof:geomhash":"45cf8e60a0b5718d6d2b98e038093a72",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108719923,
-    "wof:lastmodified":1690934541,
+    "wof:lastmodified":1695886135,
     "wof:name":"Chaldoran",
     "wof:parent_id":85672369,
     "wof:placetype":"county",

--- a/data/110/871/992/5/1108719925.geojson
+++ b/data/110/871/992/5/1108719925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.161049,
-    "geom:area_square_m":1602599391.895958,
+    "geom:area_square_m":1602599448.038889,
     "geom:bbox":"50.919657,36.152382,51.480381,36.699517",
     "geom:latitude":36.412818,
     "geom:longitude":51.207139,
@@ -145,9 +145,10 @@
         "hasc:id":"IR.MN.CH",
         "wd:id":"Q1282160"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120721,
-    "wof:geomhash":"e4ba26a84a45571fb86d6b2cc9f5f37d",
+    "wof:geomhash":"815a4c9247d2276c3acd0d99bf0deff3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108719925,
-    "wof:lastmodified":1690934541,
+    "wof:lastmodified":1695886135,
     "wof:name":"Chalus",
     "wof:parent_id":85672303,
     "wof:placetype":"county",

--- a/data/110/871/992/9/1108719929.geojson
+++ b/data/110/871/992/9/1108719929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.297817,
-    "geom:area_square_m":2938644055.151097,
+    "geom:area_square_m":2938644371.357141,
     "geom:bbox":"46.654929,36.744467,47.632015,37.364377",
     "geom:latitude":37.061292,
     "geom:longitude":47.113064,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120722,
-    "wof:geomhash":"3d3cdeb0b3f0e5a3e0166913b58e7376",
+    "wof:geomhash":"0234f5e1d3ccc7a0292076afad94559f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719929,
-    "wof:lastmodified":1627522216,
+    "wof:lastmodified":1695886692,
     "wof:name":"Charoimaq",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/871/993/1/1108719931.geojson
+++ b/data/110/871/993/1/1108719931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.331455,
-    "geom:area_square_m":3286279282.07098,
+    "geom:area_square_m":3286279282.070932,
     "geom:bbox":"58.6627596806,36.2770875571,59.3929442544,37.0508251705",
     "geom:latitude":36.695115,
     "geom:longitude":59.051661,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120723,
-    "wof:geomhash":"a472823c75db8b941f23a1f54aa6f34b",
+    "wof:geomhash":"86c975756a8ca612f1ce9ff38c7f9862",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108719931,
-    "wof:lastmodified":1566718613,
+    "wof:lastmodified":1695886135,
     "wof:name":"Chenaran",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/871/993/3/1108719933.geojson
+++ b/data/110/871/993/3/1108719933.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.BK.EG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120725,
     "wof:geomhash":"5873831a5e0b7e3065978a144207b855",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108719933,
-    "wof:lastmodified":1694498049,
+    "wof:lastmodified":1695886695,
     "wof:name":"Dalahu",
     "wof:parent_id":85672379,
     "wof:placetype":"county",

--- a/data/110/871/993/5/1108719935.geojson
+++ b/data/110/871/993/5/1108719935.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.18421,
-    "geom:area_square_m":1851520711.022553,
+    "geom:area_square_m":1851520570.010268,
     "geom:bbox":"51.806518,35.373168,52.547875,35.857818",
     "geom:latitude":35.623917,
     "geom:longitude":52.17334,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.TE.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120727,
-    "wof:geomhash":"073d7c95a734192756b4336534c4bebe",
+    "wof:geomhash":"de0c10a5ddbd875fbd983305151c3c3d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719935,
-    "wof:lastmodified":1627522217,
+    "wof:lastmodified":1695886692,
     "wof:name":"Damavand",
     "wof:parent_id":85672313,
     "wof:placetype":"county",

--- a/data/110/871/993/7/1108719937.geojson
+++ b/data/110/871/993/7/1108719937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.391379,
-    "geom:area_square_m":13995550661.209484,
+    "geom:area_square_m":13995550661.209024,
     "geom:bbox":"53.7075314185,34.243495251,54.8071179649,36.5433494402",
     "geom:latitude":35.55846,
     "geom:longitude":54.350494,
@@ -132,9 +132,10 @@
     "wof:concordances":{
         "hasc:id":"IR.SM.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120728,
-    "wof:geomhash":"8261629ff2aa7b0f5841da628d423d52",
+    "wof:geomhash":"e39b73ab94327b2a0544148444055005",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108719937,
-    "wof:lastmodified":1566718613,
+    "wof:lastmodified":1695886135,
     "wof:name":"Damghan",
     "wof:parent_id":85672309,
     "wof:placetype":"county",

--- a/data/110/871/993/9/1108719939.geojson
+++ b/data/110/871/993/9/1108719939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.606179,
-    "geom:area_square_m":6585170193.713583,
+    "geom:area_square_m":6585170193.713589,
     "geom:bbox":"54.1028291196,28.0262913569,55.452140887,28.9392228473",
     "geom:latitude":28.531635,
     "geom:longitude":54.897099,
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120729,
-    "wof:geomhash":"67afec02b3273eb655227dc9f7a2563d",
+    "wof:geomhash":"02bfba58ef6fc6457fb3565b8715ef0b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108719939,
-    "wof:lastmodified":1566718613,
+    "wof:lastmodified":1695886135,
     "wof:name":"Darab",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/871/994/1/1108719941.geojson
+++ b/data/110/871/994/1/1108719941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.395967,
-    "geom:area_square_m":3891745391.959622,
+    "geom:area_square_m":3891745391.959579,
     "geom:bbox":"58.4851224091,36.9185211129,59.4645199347,37.7052295",
     "geom:latitude":37.358756,
     "geom:longitude":59.01932,
@@ -111,9 +111,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120730,
-    "wof:geomhash":"067c1f8dc3a1e84a327e278fb633bb0f",
+    "wof:geomhash":"17155da288505be118f716a947636e40",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108719941,
-    "wof:lastmodified":1566718614,
+    "wof:lastmodified":1695886136,
     "wof:name":"Dargaz",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/871/994/3/1108719943.geojson
+++ b/data/110/871/994/3/1108719943.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KJ.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120732,
     "wof:geomhash":"983d770e5adfc56babe4e0941e65abc4",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108719943,
-    "wof:lastmodified":1694498049,
+    "wof:lastmodified":1695886692,
     "wof:name":"Darmiyan",
     "wof:parent_id":85672391,
     "wof:placetype":"county",

--- a/data/110/871/994/7/1108719947.geojson
+++ b/data/110/871/994/7/1108719947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.142551,
-    "geom:area_square_m":1475955647.956246,
+    "geom:area_square_m":1475955493.191942,
     "geom:bbox":"46.791136,32.798366,48.002183,33.488684",
     "geom:latitude":33.139359,
     "geom:longitude":47.354171,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.IL.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120733,
-    "wof:geomhash":"9b34d408e3e6a2a34e464b8e571d4b93",
+    "wof:geomhash":"411e4bf3dcb4f67d2c85e12fd1d3203c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719947,
-    "wof:lastmodified":1627522217,
+    "wof:lastmodified":1695886692,
     "wof:name":"Darrehshahr",
     "wof:parent_id":85672333,
     "wof:placetype":"county",

--- a/data/110/871/994/9/1108719949.geojson
+++ b/data/110/871/994/9/1108719949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.443661,
-    "geom:area_square_m":4678057087.45309,
+    "geom:area_square_m":4678056024.66477,
     "geom:bbox":"47.68275,30.99449,48.457724,32.060812",
     "geom:latitude":31.487879,
     "geom:longitude":47.980676,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120734,
-    "wof:geomhash":"3a3b79c44a60dd6aef9433858b69015b",
+    "wof:geomhash":"a11efb1875d3e9df13fcc6cb05e3817e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719949,
-    "wof:lastmodified":1627522217,
+    "wof:lastmodified":1695886692,
     "wof:name":"Dasht-e-Azadegan",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/871/995/1/1108719951.geojson
+++ b/data/110/871/995/1/1108719951.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.583197,
-    "geom:area_square_m":6292310686.709713,
+    "geom:area_square_m":6292310667.493049,
     "geom:bbox":"50.757399,28.661899,51.99203,29.782935",
     "geom:latitude":29.241494,
     "geom:longitude":51.350244,
@@ -145,9 +145,10 @@
         "hasc:id":"IR.BS.DN",
         "wd:id":"Q1270938"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120735,
-    "wof:geomhash":"50e6a698d6efe27086d2234bb8d0e50c",
+    "wof:geomhash":"0444298338942929bd9ae338c3538636",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108719951,
-    "wof:lastmodified":1690934541,
+    "wof:lastmodified":1695886135,
     "wof:name":"Dashtestan",
     "wof:parent_id":85672289,
     "wof:placetype":"county",

--- a/data/110/871/995/3/1108719953.geojson
+++ b/data/110/871/995/3/1108719953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.451289,
-    "geom:area_square_m":4906936604.018109,
+    "geom:area_square_m":4906936667.590607,
     "geom:bbox":"51.14301,28.112133,52.140646,28.778974",
     "geom:latitude":28.437257,
     "geom:longitude":51.62941,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.BS.DS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120737,
-    "wof:geomhash":"641840b1d77cc8c3dcbff62c21fc5edc",
+    "wof:geomhash":"cde13c781372d26ca96b52c66bfdeeba",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719953,
-    "wof:lastmodified":1627522217,
+    "wof:lastmodified":1695886693,
     "wof:name":"Dashti",
     "wof:parent_id":85672289,
     "wof:placetype":"county",

--- a/data/110/871/995/5/1108719955.geojson
+++ b/data/110/871/995/5/1108719955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.209696,
-    "geom:area_square_m":2288997518.348601,
+    "geom:area_square_m":2288998179.884798,
     "geom:bbox":"51.267056,27.824556,52.084841,28.250564",
     "geom:latitude":28.020035,
     "geom:longitude":51.687207,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.BS.DY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120738,
-    "wof:geomhash":"f89379ca3c71b529a669eecf1cb29f04",
+    "wof:geomhash":"e3299c29da62e3ed4b16e4b7abafc924",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719955,
-    "wof:lastmodified":1627522215,
+    "wof:lastmodified":1695886691,
     "wof:name":"Dayyer",
     "wof:parent_id":85672289,
     "wof:placetype":"county",

--- a/data/110/871/995/7/1108719957.geojson
+++ b/data/110/871/995/7/1108719957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.646156,
-    "geom:area_square_m":6726492569.514455,
+    "geom:area_square_m":6726492045.335806,
     "geom:bbox":"46.516039,32.045085,48.045352,33.317111",
     "geom:latitude":32.659805,
     "geom:longitude":47.286576,
@@ -108,9 +108,10 @@
     "wof:concordances":{
         "hasc:id":"IR.IL.DE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120740,
-    "wof:geomhash":"b014d1e4b8c0705736cedbc57fb8c17a",
+    "wof:geomhash":"7aabeb806a231cf683e62cd9c8dee1f3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108719957,
-    "wof:lastmodified":1627522217,
+    "wof:lastmodified":1695886693,
     "wof:name":"Dehloran",
     "wof:parent_id":85672333,
     "wof:placetype":"county",

--- a/data/110/871/995/9/1108719959.geojson
+++ b/data/110/871/995/9/1108719959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.268082,
-    "geom:area_square_m":2746175038.05318,
+    "geom:area_square_m":2746175368.824616,
     "geom:bbox":"47.424018,33.834067,48.330321,34.378082",
     "geom:latitude":34.061382,
     "geom:longitude":47.822828,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.LO.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120741,
-    "wof:geomhash":"726699d73555840e9e0ef5aadbdb2b75",
+    "wof:geomhash":"d3a827175b8397a70183585e6a338a2e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719959,
-    "wof:lastmodified":1627522217,
+    "wof:lastmodified":1695886693,
     "wof:name":"Delfan",
     "wof:parent_id":85672329,
     "wof:placetype":"county",

--- a/data/110/871/996/1/1108719961.geojson
+++ b/data/110/871/996/1/1108719961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.215749,
-    "geom:area_square_m":2211155763.980363,
+    "geom:area_square_m":2211155763.980211,
     "geom:bbox":"50.2508344807,33.70149175,51.0503916359,34.3448996098",
     "geom:latitude":34.020295,
     "geom:longitude":50.746869,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MK.DE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120742,
-    "wof:geomhash":"505c2542ba307f81d20319f8e42d9539",
+    "wof:geomhash":"eef6f96c0144a28651894b132a333379",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108719961,
-    "wof:lastmodified":1566718607,
+    "wof:lastmodified":1695886132,
     "wof:name":"Delijan",
     "wof:parent_id":85672347,
     "wof:placetype":"county",

--- a/data/110/871/996/5/1108719965.geojson
+++ b/data/110/871/996/5/1108719965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.150552,
-    "geom:area_square_m":1596401837.749441,
+    "geom:area_square_m":1596401837.749409,
     "geom:bbox":"50.9507949899,30.6575192823,51.5923110267,31.2228387513",
     "geom:latitude":30.958406,
     "geom:longitude":51.26014,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KB.DE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120744,
-    "wof:geomhash":"1b0fa763847a471e26623679e854f1c8",
+    "wof:geomhash":"c323a39d6d776cb2c350dfb2bbc30b63",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108719965,
-    "wof:lastmodified":1566718607,
+    "wof:lastmodified":1695886132,
     "wof:name":"Dena",
     "wof:parent_id":85672283,
     "wof:placetype":"county",

--- a/data/110/871/996/7/1108719967.geojson
+++ b/data/110/871/996/7/1108719967.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.160451,
-    "geom:area_square_m":1717809511.032907,
+    "geom:area_square_m":1717809586.491235,
     "geom:bbox":"50.107082,29.745814,50.658364,30.292324",
     "geom:latitude":30.022652,
     "geom:longitude":50.344457,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.BS.DM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120745,
-    "wof:geomhash":"6173f2430e8e9c4a1b33101a72ca93ff",
+    "wof:geomhash":"1f33bde26ff61e822bab26bc5aeb7d75",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719967,
-    "wof:lastmodified":1627522217,
+    "wof:lastmodified":1695886693,
     "wof:name":"Deylam",
     "wof:parent_id":85672289,
     "wof:placetype":"county",

--- a/data/110/871/996/9/1108719969.geojson
+++ b/data/110/871/996/9/1108719969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.445818,
-    "geom:area_square_m":4645374735.349601,
+    "geom:area_square_m":4645375035.727198,
     "geom:bbox":"48.281291,31.998714,49.562058,32.967219",
     "geom:latitude":32.575285,
     "geom:longitude":48.840905,
@@ -180,9 +180,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.DE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120746,
-    "wof:geomhash":"77a6232e8e0d00faaac1d7bd3c563633",
+    "wof:geomhash":"59c343f93f74cc318a169b5d64769f7d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -192,7 +193,7 @@
         }
     ],
     "wof:id":1108719969,
-    "wof:lastmodified":1636495418,
+    "wof:lastmodified":1695886653,
     "wof:name":"Dezful",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/871/997/1/1108719971.geojson
+++ b/data/110/871/997/1/1108719971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.394285,
-    "geom:area_square_m":3947938109.383456,
+    "geom:area_square_m":3947937559.812365,
     "geom:bbox":"46.518527,35.575543,47.486523,36.349133",
     "geom:latitude":35.926635,
     "geom:longitude":46.972177,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KD.DI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120747,
-    "wof:geomhash":"ee0c35c2318f3d825fb6a629c8bb45c3",
+    "wof:geomhash":"8baca63fb7f8e6a182289ad2c11bc1cc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108719971,
-    "wof:lastmodified":1627522217,
+    "wof:lastmodified":1695886693,
     "wof:name":"Divandarreh",
     "wof:parent_id":85672387,
     "wof:placetype":"county",

--- a/data/110/871/997/3/1108719973.geojson
+++ b/data/110/871/997/3/1108719973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134988,
-    "geom:area_square_m":1391451639.350035,
+    "geom:area_square_m":1391451712.813963,
     "geom:bbox":"48.789547,33.285823,49.325278,33.751562",
     "geom:latitude":33.52634,
     "geom:longitude":49.074228,
@@ -145,9 +145,10 @@
         "hasc:id":"IR.LO.DO",
         "wd:id":"Q1279194"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120749,
-    "wof:geomhash":"d4864f096aefdf5f543b712ece769ef1",
+    "wof:geomhash":"14f81398fb8aa865c2ca982003c7b431",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108719973,
-    "wof:lastmodified":1690934539,
+    "wof:lastmodified":1695886133,
     "wof:name":"Dorud",
     "wof:parent_id":85672329,
     "wof:placetype":"county",

--- a/data/110/871/997/5/1108719975.geojson
+++ b/data/110/871/997/5/1108719975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.67383,
-    "geom:area_square_m":7162643087.487401,
+    "geom:area_square_m":7162643087.487552,
     "geom:bbox":"51.7894797628,30.2330984538,52.9150145412,31.2093837229",
     "geom:latitude":30.721959,
     "geom:longitude":52.396714,
@@ -120,9 +120,10 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.EQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120750,
-    "wof:geomhash":"36997726fae401430a5002252c70a85c",
+    "wof:geomhash":"0aa322c7a304ebb9d47fd3e9a3f09927",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108719975,
-    "wof:lastmodified":1566718608,
+    "wof:lastmodified":1695886133,
     "wof:name":"Eqlid",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/871/997/7/1108719977.geojson
+++ b/data/110/871/997/7/1108719977.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.502037,
-    "geom:area_square_m":15708272021.48452,
+    "geom:area_square_m":15708273020.595154,
     "geom:bbox":"51.527002,31.487607,53.205318,33.014251",
     "geom:latitude":32.244514,
     "geom:longitude":52.44332,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120752,
-    "wof:geomhash":"0b669eb88124ea0bc90ccfa823b506f7",
+    "wof:geomhash":"575b22f213e904bc914219c9afe80d94",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719977,
-    "wof:lastmodified":1627522219,
+    "wof:lastmodified":1695886694,
     "wof:name":"Esfahan",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/871/997/9/1108719979.geojson
+++ b/data/110/871/997/9/1108719979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.501629,
-    "geom:area_square_m":4956711004.157893,
+    "geom:area_square_m":4956711950.381834,
     "geom:bbox":"56.973441,36.580262,58.126321,37.282808",
     "geom:latitude":36.953886,
     "geom:longitude":57.555472,
@@ -142,9 +142,10 @@
         "hasc:id":"IR.KS.ES",
         "wd:id":"Q1286451"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120754,
-    "wof:geomhash":"86c1e5d3bcf9756326b37ea8bd332078",
+    "wof:geomhash":"826ed18f1d5e77b740f4424d6454cbce",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108719979,
-    "wof:lastmodified":1690934538,
+    "wof:lastmodified":1695886133,
     "wof:name":"Esfarayen",
     "wof:parent_id":85672401,
     "wof:placetype":"county",

--- a/data/110/871/998/3/1108719983.geojson
+++ b/data/110/871/998/3/1108719983.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.BK.EG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120755,
     "wof:geomhash":"bea11b7c728dbaa40c388cb668982b2b",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108719983,
-    "wof:lastmodified":1694498049,
+    "wof:lastmodified":1695886693,
     "wof:name":"Eslamabad-e-Gharb",
     "wof:parent_id":85672379,
     "wof:placetype":"county",

--- a/data/110/871/998/5/1108719985.geojson
+++ b/data/110/871/998/5/1108719985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018177,
-    "geom:area_square_m":182802248.618802,
+    "geom:area_square_m":182802248.618847,
     "geom:bbox":"51.1760949838,35.4755160464,51.3541920764,35.6696774434",
     "geom:latitude":35.577582,
     "geom:longitude":51.246235,
@@ -162,9 +162,10 @@
     "wof:concordances":{
         "hasc:id":"IR.TE.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120757,
-    "wof:geomhash":"1fd7259dc5ea3fcac4bdbc61cefe739a",
+    "wof:geomhash":"9a3b99b4f808668f2ff35a511abc06d1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":1108719985,
-    "wof:lastmodified":1566718606,
+    "wof:lastmodified":1695886132,
     "wof:name":"Eslamshahr",
     "wof:parent_id":85672313,
     "wof:placetype":"county",

--- a/data/110/871/998/7/1108719987.geojson
+++ b/data/110/871/998/7/1108719987.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.185776,
-    "geom:area_square_m":2006287709.205518,
+    "geom:area_square_m":2006287709.205838,
     "geom:bbox":"53.5771006377,28.8347489962,54.4810387376,29.5133719216",
     "geom:latitude":29.146008,
     "geom:longitude":54.003823,
@@ -114,9 +114,10 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.ES"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120758,
-    "wof:geomhash":"0ad3ac3a612baa95c9ac4f3ee22c5560",
+    "wof:geomhash":"0657c78863f5625d3fb72f8ffa0d6619",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108719987,
-    "wof:lastmodified":1566718606,
+    "wof:lastmodified":1695886132,
     "wof:name":"Estahban",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/871/998/9/1108719989.geojson
+++ b/data/110/871/998/9/1108719989.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032446,
-    "geom:area_square_m":338285462.672149,
+    "geom:area_square_m":338285352.442672,
     "geom:bbox":"51.421399,32.426904,51.678142,32.620944",
     "geom:latitude":32.521408,
     "geom:longitude":51.538864,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.FL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120760,
-    "wof:geomhash":"4f7554fb2f7406149076dd36a9a9466f",
+    "wof:geomhash":"9a476c4c61b54215dfaf38f8963a4668",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108719989,
-    "wof:lastmodified":1627522218,
+    "wof:lastmodified":1695886693,
     "wof:name":"Falavarjan",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/871/999/1/1108719991.geojson
+++ b/data/110/871/999/1/1108719991.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.445877,
-    "geom:area_square_m":4839537228.687538,
+    "geom:area_square_m":4839538053.643567,
     "geom:bbox":"51.797612,28.015103,52.53714,29.186955",
     "geom:latitude":28.622347,
     "geom:longitude":52.209753,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.FB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120761,
-    "wof:geomhash":"8feb99fcdef207b71e5da7e535579844",
+    "wof:geomhash":"724049416787fd811631081415396aef",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108719991,
-    "wof:lastmodified":1627522218,
+    "wof:lastmodified":1695886693,
     "wof:name":"Farashband",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/871/999/3/1108719993.geojson
+++ b/data/110/871/999/3/1108719993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.193896,
-    "geom:area_square_m":2009145609.152883,
+    "geom:area_square_m":2009146407.187191,
     "geom:bbox":"49.872424,32.751303,50.632072,33.361522",
     "geom:latitude":33.070612,
     "geom:longitude":50.240725,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.FD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120762,
-    "wof:geomhash":"2370da39cf5e066de07b05da0e177cda",
+    "wof:geomhash":"c926b067926c0abec6a4ee24bc0275d4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108719993,
-    "wof:lastmodified":1627522218,
+    "wof:lastmodified":1695886693,
     "wof:name":"Faridan",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/871/999/5/1108719995.geojson
+++ b/data/110/871/999/5/1108719995.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.326795,
-    "geom:area_square_m":3281690201.138822,
+    "geom:area_square_m":3281690278.784382,
     "geom:bbox":"59.487113,35.436279,60.57999,36.022286",
     "geom:latitude":35.696029,
     "geom:longitude":59.879043,
@@ -133,9 +133,10 @@
         "hasc:id":"IR.KV.FA",
         "wd:id":"Q301694"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120763,
-    "wof:geomhash":"a588776dfa89a336e1d3ccc35da56ca7",
+    "wof:geomhash":"46af3b848ac8730c41465fc922f60085",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108719995,
-    "wof:lastmodified":1690934539,
+    "wof:lastmodified":1695886133,
     "wof:name":"Fariman",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/871/999/7/1108719997.geojson
+++ b/data/110/871/999/7/1108719997.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053106,
-    "geom:area_square_m":555496828.713605,
+    "geom:area_square_m":555496828.713513,
     "geom:bbox":"50.3566641898,32.0573229666,50.7594208947,32.3822205978",
     "geom:latitude":32.227514,
     "geom:longitude":50.562773,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"IR.CM.FA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120765,
-    "wof:geomhash":"3c557d4577de07e7c44a8bf2997717de",
+    "wof:geomhash":"2d6a62aaad811707ad589e98ce888566",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108719997,
-    "wof:lastmodified":1566718608,
+    "wof:lastmodified":1695886133,
     "wof:name":"Farsan",
     "wof:parent_id":85672319,
     "wof:placetype":"county",

--- a/data/110/872/000/1/1108720001.geojson
+++ b/data/110/872/000/1/1108720001.geojson
@@ -77,6 +77,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.QU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120766,
     "wof:geomhash":"c3b2aecda2e6712f5b62d6327cdb479d",
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108720001,
-    "wof:lastmodified":1694498049,
+    "wof:lastmodified":1695886693,
     "wof:name":"Faruj",
     "wof:parent_id":85672401,
     "wof:placetype":"county",

--- a/data/110/872/000/3/1108720003.geojson
+++ b/data/110/872/000/3/1108720003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.389768,
-    "geom:area_square_m":4217343818.130926,
+    "geom:area_square_m":4217343621.048287,
     "geom:bbox":"53.340687,28.503744,54.258524,29.426135",
     "geom:latitude":28.948619,
     "geom:longitude":53.784153,
@@ -142,9 +142,10 @@
         "hasc:id":"IR.FA.FA",
         "wd:id":"Q548013"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120767,
-    "wof:geomhash":"44260f74a6acf9b6efaa7988c2aa6aea",
+    "wof:geomhash":"45c4a5bfbb627363f0a20aa6693bd45f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108720003,
-    "wof:lastmodified":1690934452,
+    "wof:lastmodified":1695886651,
     "wof:name":"Fasa",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/872/000/5/1108720005.geojson
+++ b/data/110/872/000/5/1108720005.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.976654,
-    "geom:area_square_m":10010119877.75647,
+    "geom:area_square_m":10010119877.755447,
     "geom:bbox":"57.0064479781,33.4628406727,58.4970529955,34.621034153",
     "geom:latitude":34.014183,
     "geom:longitude":57.665915,
@@ -132,9 +132,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.FE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120768,
-    "wof:geomhash":"82ef83b2851c4e0aeae9f8edbfedbe00",
+    "wof:geomhash":"f6a388a4f619afbb894bbc92ac448a00",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108720005,
-    "wof:lastmodified":1566718585,
+    "wof:lastmodified":1695886123,
     "wof:name":"Ferdows",
     "wof:parent_id":85672391,
     "wof:placetype":"county",

--- a/data/110/872/000/7/1108720007.geojson
+++ b/data/110/872/000/7/1108720007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.208293,
-    "geom:area_square_m":2163624954.846869,
+    "geom:area_square_m":2163624331.300086,
     "geom:bbox":"49.639404,32.613741,50.323246,33.083679",
     "geom:latitude":32.854167,
     "geom:longitude":50.001112,
@@ -108,9 +108,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.FE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120770,
-    "wof:geomhash":"a1b822db572eb931b085ceb275f55aa5",
+    "wof:geomhash":"1c9c35606f7656c04bca9fcdf9ebd9e8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108720007,
-    "wof:lastmodified":1627522218,
+    "wof:lastmodified":1695886694,
     "wof:name":"Fereydunshahr",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/872/000/9/1108720009.geojson
+++ b/data/110/872/000/9/1108720009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.32914,
-    "geom:area_square_m":3563135432.298104,
+    "geom:area_square_m":3563134867.352663,
     "geom:bbox":"52.116494,28.468929,52.961783,29.256584",
     "geom:latitude":28.896457,
     "geom:longitude":52.561685,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.FI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120771,
-    "wof:geomhash":"d7cf198a39db269f50bc5fc28ad05990",
+    "wof:geomhash":"2939d0d09cd4538a9251c84f9b25eb90",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108720009,
-    "wof:lastmodified":1627522218,
+    "wof:lastmodified":1695886694,
     "wof:name":"Firuzabad",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/872/001/1/1108720011.geojson
+++ b/data/110/872/001/1/1108720011.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.237042,
-    "geom:area_square_m":2380098911.056632,
+    "geom:area_square_m":2380099380.205004,
     "geom:bbox":"52.239525,35.338202,53.156625,35.945476",
     "geom:latitude":35.705777,
     "geom:longitude":52.659187,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.TE.FI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120772,
-    "wof:geomhash":"a20fc20ece3dcf531cb942fe4da54548",
+    "wof:geomhash":"f30a477fcf393547825845224c649886",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720011,
-    "wof:lastmodified":1627522218,
+    "wof:lastmodified":1695886694,
     "wof:name":"Firuzkuh",
     "wof:parent_id":85672313,
     "wof:placetype":"county",

--- a/data/110/872/001/3/1108720013.geojson
+++ b/data/110/872/001/3/1108720013.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102678,
-    "geom:area_square_m":1011521322.378247,
+    "geom:area_square_m":1011521786.346442,
     "geom:bbox":"48.872963,37.000656,49.425451,37.345201",
     "geom:latitude":37.183436,
     "geom:longitude":49.133771,
@@ -148,9 +148,10 @@
         "hasc:id":"IR.GI.FU",
         "wd:id":"Q1289677"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120774,
-    "wof:geomhash":"c921c79ab2cf315e0aa1c94dd2399de2",
+    "wof:geomhash":"686d31eeb9c3c3301778d7715948ac3f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1108720013,
-    "wof:lastmodified":1690934529,
+    "wof:lastmodified":1695886125,
     "wof:name":"Fuman",
     "wof:parent_id":85672383,
     "wof:placetype":"county",

--- a/data/110/872/001/5/1108720015.geojson
+++ b/data/110/872/001/5/1108720015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.391454,
-    "geom:area_square_m":4177673474.055439,
+    "geom:area_square_m":4177673244.26504,
     "geom:bbox":"50.384116,29.925929,51.296392,30.679372",
     "geom:latitude":30.334911,
     "geom:longitude":50.827852,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KB.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120775,
-    "wof:geomhash":"edc7e4d9d260bbf77a67c70afd69e91d",
+    "wof:geomhash":"52da165a75e55043c566148efacf1eba",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720015,
-    "wof:lastmodified":1627522218,
+    "wof:lastmodified":1695886694,
     "wof:name":"Gachsaran",
     "wof:parent_id":85672283,
     "wof:placetype":"county",

--- a/data/110/872/001/9/1108720019.geojson
+++ b/data/110/872/001/9/1108720019.geojson
@@ -80,6 +80,7 @@
     "wof:concordances":{
         "hasc:id":"IR.GO.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120776,
     "wof:geomhash":"95d1c80db8bd27967aa0f07c60cd4576",
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108720019,
-    "wof:lastmodified":1694498049,
+    "wof:lastmodified":1695886694,
     "wof:name":"Galugah",
     "wof:parent_id":85672303,
     "wof:placetype":"county",

--- a/data/110/872/002/1/1108720021.geojson
+++ b/data/110/872/002/1/1108720021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.209781,
-    "geom:area_square_m":2014875770.122528,
+    "geom:area_square_m":2014876316.854964,
     "geom:bbox":"47.499319,38.829035,48.339592,39.228297",
     "geom:latitude":39.035953,
     "geom:longitude":47.879068,
@@ -136,9 +136,10 @@
         "hasc:id":"IR.AR.GE",
         "wd:id":"Q1274543"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120777,
-    "wof:geomhash":"a174cf878838008b71d5ec6d9416637e",
+    "wof:geomhash":"5e23bf836abef64222e622fa85feaa7e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1108720021,
-    "wof:lastmodified":1690934537,
+    "wof:lastmodified":1695886131,
     "wof:name":"Garmi",
     "wof:parent_id":85672343,
     "wof:placetype":"county",

--- a/data/110/872/002/3/1108720023.geojson
+++ b/data/110/872/002/3/1108720023.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.940121,
-    "geom:area_square_m":9530642077.947472,
+    "geom:area_square_m":9530641835.717148,
     "geom:bbox":"51.833966,34.301703,52.858098,35.578267",
     "geom:latitude":34.928437,
     "geom:longitude":52.383332,
@@ -142,9 +142,10 @@
         "hasc:id":"IR.SM.GA",
         "wd:id":"Q1286379"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120779,
-    "wof:geomhash":"1939dedc99b84446218f028a283b5d22",
+    "wof:geomhash":"c003bc7be33c38f34f5182bcfe30003d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108720023,
-    "wof:lastmodified":1690934537,
+    "wof:lastmodified":1695886132,
     "wof:name":"Garmsar",
     "wof:parent_id":85672309,
     "wof:placetype":"county",

--- a/data/110/872/002/5/1108720025.geojson
+++ b/data/110/872/002/5/1108720025.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.HG.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120780,
     "wof:geomhash":"891ed454ec2a4d4bfeaec8cb825b7afa",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108720025,
-    "wof:lastmodified":1694498050,
+    "wof:lastmodified":1695886700,
     "wof:name":"Gavbandi",
     "wof:parent_id":85672337,
     "wof:placetype":"county",

--- a/data/110/872/002/7/1108720027.geojson
+++ b/data/110/872/002/7/1108720027.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.166479,
-    "geom:area_square_m":1789603439.73658,
+    "geom:area_square_m":1789604000.843516,
     "geom:bbox":"50.319379,29.152746,50.85153,29.915251",
     "geom:latitude":29.615697,
     "geom:longitude":50.631149,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.BS.GE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120781,
-    "wof:geomhash":"f7cf1b3ae4239929be48db8ae997b0b1",
+    "wof:geomhash":"7366efa3e10d6ec14ee39a025b9884c4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720027,
-    "wof:lastmodified":1627522218,
+    "wof:lastmodified":1695886694,
     "wof:name":"Genaveh",
     "wof:parent_id":85672289,
     "wof:placetype":"county",

--- a/data/110/872/002/9/1108720029.geojson
+++ b/data/110/872/002/9/1108720029.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KE.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120783,
     "wof:geomhash":"1228625d92810c5e854a18ffea55d96e",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108720029,
-    "wof:lastmodified":1694498049,
+    "wof:lastmodified":1695886694,
     "wof:name":"Ghaleh-Ganj",
     "wof:parent_id":85672409,
     "wof:placetype":"county",

--- a/data/110/872/003/1/1108720031.geojson
+++ b/data/110/872/003/1/1108720031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.217662,
-    "geom:area_square_m":2228085133.020084,
+    "geom:area_square_m":2228084967.508828,
     "geom:bbox":"45.638038,33.829438,46.672967,34.422978",
     "geom:latitude":34.121966,
     "geom:longitude":46.022233,
@@ -124,9 +124,10 @@
         "hasc:id":"IR.BK.GG",
         "wd:id":"Q1294730"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120784,
-    "wof:geomhash":"6e7263a709b4fac7b3510ece994de7f2",
+    "wof:geomhash":"9bd13b60767e16b4019d19dce767a631",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1108720031,
-    "wof:lastmodified":1690934535,
+    "wof:lastmodified":1695886130,
     "wof:name":"Gilan-e-Gharb",
     "wof:parent_id":85672379,
     "wof:placetype":"county",

--- a/data/110/872/003/3/1108720033.geojson
+++ b/data/110/872/003/3/1108720033.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.159005,
-    "geom:area_square_m":1640469278.361049,
+    "geom:area_square_m":1640469278.360917,
     "geom:bbox":"49.9479634001,33.2331380689,50.7617972811,33.6411171471",
     "geom:latitude":33.449817,
     "geom:longitude":50.387939,
@@ -108,9 +108,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120785,
-    "wof:geomhash":"83798dba7eda1c3b8e9bdd03c7be59e5",
+    "wof:geomhash":"bf98d5712185a697764216f448c37af7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108720033,
-    "wof:lastmodified":1566718600,
+    "wof:lastmodified":1695886130,
     "wof:name":"Golpayegan",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/872/003/7/1108720037.geojson
+++ b/data/110/872/003/7/1108720037.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.001947,
-    "geom:area_square_m":10212116816.274391,
+    "geom:area_square_m":10212116884.345337,
     "geom:bbox":"57.557485,34.021058,59.532947,34.925499",
     "geom:latitude":34.484805,
     "geom:longitude":58.493238,
@@ -136,9 +136,10 @@
         "hasc:id":"IR.KV.GO",
         "wd:id":"Q1270649"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120786,
-    "wof:geomhash":"cc588f32890a31a9b2a65a68178577e5",
+    "wof:geomhash":"c6465f144d99e564f6b96a35e287f13a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1108720037,
-    "wof:lastmodified":1690934534,
+    "wof:lastmodified":1695886130,
     "wof:name":"Gonabad",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/872/003/9/1108720039.geojson
+++ b/data/110/872/003/9/1108720039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.509231,
-    "geom:area_square_m":4991364171.4363,
+    "geom:area_square_m":4991364837.086427,
     "geom:bbox":"54.553212,37.065355,55.665234,38.108221",
     "geom:latitude":37.561653,
     "geom:longitude":55.104718,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GO.GK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120788,
-    "wof:geomhash":"9cdc62a55e60e4295acca1e07387a81b",
+    "wof:geomhash":"9830a78feeedf74da98b547770884e53",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720039,
-    "wof:lastmodified":1627522219,
+    "wof:lastmodified":1695886694,
     "wof:name":"Gonbad-e-Kavus",
     "wof:parent_id":85672299,
     "wof:placetype":"county",

--- a/data/110/872/004/1/1108720041.geojson
+++ b/data/110/872/004/1/1108720041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.158365,
-    "geom:area_square_m":1569034152.695636,
+    "geom:area_square_m":1569034152.695733,
     "geom:bbox":"54.2212634026,36.5112430893,54.7446474336,36.9642208908",
     "geom:latitude":36.749581,
     "geom:longitude":54.505896,
@@ -219,9 +219,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GO.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120794,
-    "wof:geomhash":"57952276d9b32b18c858d9b10e32d4a9",
+    "wof:geomhash":"e1f1dff0d0baccf2df18f4ee87475516",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -231,7 +232,7 @@
         }
     ],
     "wof:id":1108720041,
-    "wof:lastmodified":1566718601,
+    "wof:lastmodified":1695886130,
     "wof:name":"Gorgan",
     "wof:parent_id":85672299,
     "wof:placetype":"county",

--- a/data/110/872/004/3/1108720043.geojson
+++ b/data/110/872/004/3/1108720043.geojson
@@ -89,6 +89,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120796,
     "wof:geomhash":"981f2d0b5f711665d672273d0a86e362",
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108720043,
-    "wof:lastmodified":1694498049,
+    "wof:lastmodified":1695886695,
     "wof:name":"Gotvand",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/872/004/5/1108720045.geojson
+++ b/data/110/872/004/5/1108720045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.870759,
-    "geom:area_square_m":9485432432.389454,
+    "geom:area_square_m":9485433259.628496,
     "geom:bbox":"55.242413,27.722246,57.011287,28.883155",
     "geom:latitude":28.239947,
     "geom:longitude":56.008783,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.HG.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120797,
-    "wof:geomhash":"8fc4806752b8536762a9c3d7a5578189",
+    "wof:geomhash":"ebf799b915b484d79d1f21140eb3281e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720045,
-    "wof:lastmodified":1627522219,
+    "wof:lastmodified":1695886695,
     "wof:name":"Hajiabad",
     "wof:parent_id":85672337,
     "wof:placetype":"county",

--- a/data/110/872/004/7/1108720047.geojson
+++ b/data/110/872/004/7/1108720047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.409206,
-    "geom:area_square_m":4149138564.16013,
+    "geom:area_square_m":4149138446.234594,
     "geom:bbox":"48.353983,34.58484,49.467432,35.249495",
     "geom:latitude":34.914607,
     "geom:longitude":48.929664,
@@ -163,9 +163,10 @@
         "hasc:id":"IR.HD.HA",
         "wd:id":"Q1279518"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120798,
-    "wof:geomhash":"a89c8a13c81e4e2148a2df148618c8eb",
+    "wof:geomhash":"0811089dbe069e0f8e9fec1f2c4629a5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":1108720047,
-    "wof:lastmodified":1690934535,
+    "wof:lastmodified":1695886130,
     "wof:name":"Hamedan",
     "wof:parent_id":85672355,
     "wof:placetype":"county",

--- a/data/110/872/004/9/1108720049.geojson
+++ b/data/110/872/004/9/1108720049.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.239016,
-    "geom:area_square_m":2321648937.978184,
+    "geom:area_square_m":2321649124.283509,
     "geom:bbox":"46.375868,38.057106,47.377321,38.405303",
     "geom:latitude":38.229173,
     "geom:longitude":46.823059,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.HR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120799,
-    "wof:geomhash":"c782a4843db7af86134fe48e82d83c01",
+    "wof:geomhash":"346654b1a51fb02308690891eade5ee4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108720049,
-    "wof:lastmodified":1627522219,
+    "wof:lastmodified":1695886695,
     "wof:name":"Haris",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/872/005/1/1108720051.geojson
+++ b/data/110/872/005/1/1108720051.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098898,
-    "geom:area_square_m":1009652730.918929,
+    "geom:area_square_m":1009653295.531191,
     "geom:bbox":"47.247068,34.100064,47.696967,34.580082",
     "geom:latitude":34.347464,
     "geom:longitude":47.4538,
@@ -148,9 +148,10 @@
         "hasc:id":"IR.BK.HA",
         "wd:id":"Q1286867"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120801,
-    "wof:geomhash":"1bf003030f2d06ea1d84a43081e07267",
+    "wof:geomhash":"b3c12ecc5863684d6f568c366d1baebe",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1108720051,
-    "wof:lastmodified":1690934536,
+    "wof:lastmodified":1695886131,
     "wof:name":"Harsin",
     "wof:parent_id":85672379,
     "wof:placetype":"county",

--- a/data/110/872/005/5/1108720055.geojson
+++ b/data/110/872/005/5/1108720055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.233531,
-    "geom:area_square_m":2293235158.45441,
+    "geom:area_square_m":2293234451.149108,
     "geom:bbox":"46.468553,37.147852,47.316523,37.641691",
     "geom:latitude":37.424667,
     "geom:longitude":46.903746,
@@ -114,9 +114,10 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.HS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120802,
-    "wof:geomhash":"e5bbcea2cf96832b3d2d400bb495538d",
+    "wof:geomhash":"456ffe13ea324af3dff90a5669eb09c1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108720055,
-    "wof:lastmodified":1627522219,
+    "wof:lastmodified":1695886695,
     "wof:name":"Hashtrud",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/872/005/7/1108720057.geojson
+++ b/data/110/872/005/7/1108720057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.363376,
-    "geom:area_square_m":3878428745.93552,
+    "geom:area_square_m":3878429012.013659,
     "geom:bbox":"48.917084,30.000416,50.197306,30.598187",
     "geom:latitude":30.324805,
     "geom:longitude":49.58218,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120803,
-    "wof:geomhash":"299efa15ee348802ab47ba8d74470086",
+    "wof:geomhash":"9000f3462c61da67c2ca976c35c96d16",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108720057,
-    "wof:lastmodified":1627522219,
+    "wof:lastmodified":1695886695,
     "wof:name":"Hendijan",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/872/005/9/1108720059.geojson
+++ b/data/110/872/005/9/1108720059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.188986,
-    "geom:area_square_m":1882276213.088912,
+    "geom:area_square_m":1882276592.837069,
     "geom:bbox":"47.872768,36.078842,48.580963,36.564316",
     "geom:latitude":36.343542,
     "geom:longitude":48.198213,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ZA.IJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120805,
-    "wof:geomhash":"4856f2bdbdc557595c9caf7fc838d1c4",
+    "wof:geomhash":"079c9b088c952d15cfaae6bbd0136903",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720059,
-    "wof:lastmodified":1627522219,
+    "wof:lastmodified":1695886695,
     "wof:name":"Ijerud",
     "wof:parent_id":85672361,
     "wof:placetype":"county",

--- a/data/110/872/006/1/1108720061.geojson
+++ b/data/110/872/006/1/1108720061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.193633,
-    "geom:area_square_m":1993190758.462471,
+    "geom:area_square_m":1993190507.705775,
     "geom:bbox":"45.69466,33.360519,46.856076,33.860719",
     "geom:latitude":33.646704,
     "geom:longitude":46.212745,
@@ -124,9 +124,10 @@
     "wof:concordances":{
         "hasc:id":"IR.IL.IL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120806,
-    "wof:geomhash":"af2c354872d717ea7c92359c7e87b64e",
+    "wof:geomhash":"3f65a7d20616abccc7b42f0705de6d24",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1108720061,
-    "wof:lastmodified":1636495415,
+    "wof:lastmodified":1695886651,
     "wof:name":"Ilam",
     "wof:parent_id":85672333,
     "wof:placetype":"county",

--- a/data/110/872/006/3/1108720063.geojson
+++ b/data/110/872/006/3/1108720063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.841359,
-    "geom:area_square_m":31129973019.43549,
+    "geom:area_square_m":31129973428.018719,
     "geom:bbox":"58.828632,26.758449,61.243445,28.72875",
     "geom:latitude":27.617092,
     "geom:longitude":59.83537,
@@ -142,9 +142,10 @@
         "hasc:id":"IR.SB.IR",
         "wd:id":"Q1278141"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120807,
-    "wof:geomhash":"2482c756170f8bf439d470e8b487e5b6",
+    "wof:geomhash":"e1c4b710b491cdb98f5b96625a2ec155",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108720063,
-    "wof:lastmodified":1690934530,
+    "wof:lastmodified":1695886126,
     "wof:name":"Iranshahr",
     "wof:parent_id":85672405,
     "wof:placetype":"county",

--- a/data/110/872/006/5/1108720065.geojson
+++ b/data/110/872/006/5/1108720065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08807,
-    "geom:area_square_m":904075625.34672,
+    "geom:area_square_m":904075457.862218,
     "geom:bbox":"45.84547,33.675132,46.457152,34.037425",
     "geom:latitude":33.88189,
     "geom:longitude":46.173476,
@@ -105,9 +105,10 @@
     "wof:concordances":{
         "hasc:id":"IR.IL.EY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120808,
-    "wof:geomhash":"69884b815c2f0e0d799adb8360beb3fe",
+    "wof:geomhash":"6b226ad0a3afaf1d44ad280a12fca568",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108720065,
-    "wof:lastmodified":1627522219,
+    "wof:lastmodified":1695886695,
     "wof:name":"Ivan",
     "wof:parent_id":85672333,
     "wof:placetype":"county",

--- a/data/110/872/006/7/1108720067.geojson
+++ b/data/110/872/006/7/1108720067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.362393,
-    "geom:area_square_m":3805399330.377243,
+    "geom:area_square_m":3805399330.376697,
     "geom:bbox":"49.5568060706,31.443479982,50.4400041444,32.34789174",
     "geom:latitude":31.872667,
     "geom:longitude":49.973085,
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.IZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120810,
-    "wof:geomhash":"69ddb47a4fb774de8687b71838d34c4e",
+    "wof:geomhash":"9f1a88e106a9b5f2f3834a6b0f03d4ae",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108720067,
-    "wof:lastmodified":1566718591,
+    "wof:lastmodified":1695886126,
     "wof:name":"Izeh",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/872/006/9/1108720069.geojson
+++ b/data/110/872/006/9/1108720069.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.529184,
-    "geom:area_square_m":5739781965.111331,
+    "geom:area_square_m":5739781965.110762,
     "geom:bbox":"52.7612211147,28.2873652896,54.0457900133,29.1267468722",
     "geom:latitude":28.695482,
     "geom:longitude":53.351434,
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120811,
-    "wof:geomhash":"e8597aebb1b16fc979058243c7ba7d18",
+    "wof:geomhash":"8aa2353655c2fa12f996f0ab2b73a946",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108720069,
-    "wof:lastmodified":1566718591,
+    "wof:lastmodified":1695886126,
     "wof:name":"Jahrom",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/872/007/3/1108720073.geojson
+++ b/data/110/872/007/3/1108720073.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.571384,
-    "geom:area_square_m":5636585884.103032,
+    "geom:area_square_m":5636585379.635983,
     "geom:bbox":"55.90808,36.665001,57.0329,37.397614",
     "geom:latitude":37.080392,
     "geom:longitude":56.503976,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KS.JJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120812,
-    "wof:geomhash":"1a1404f5aeb90f0ff59508aa58d5d631",
+    "wof:geomhash":"586180c79383801d5eae20956ffde6c7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108720073,
-    "wof:lastmodified":1627522219,
+    "wof:lastmodified":1695886695,
     "wof:name":"Jajarm",
     "wof:parent_id":85672401,
     "wof:placetype":"county",

--- a/data/110/872/007/5/1108720075.geojson
+++ b/data/110/872/007/5/1108720075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124839,
-    "geom:area_square_m":1363775674.880812,
+    "geom:area_square_m":1363775362.802989,
     "geom:bbox":"51.865408,27.669918,52.537887,28.172851",
     "geom:latitude":27.935825,
     "geom:longitude":52.238138,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"IR.BS.JM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120814,
-    "wof:geomhash":"52fbbce02d74ac5b69a9fedc08569705",
+    "wof:geomhash":"dadfada75d6b95f82a8935e0f0613167",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108720075,
-    "wof:lastmodified":1627522220,
+    "wof:lastmodified":1695886695,
     "wof:name":"Jam",
     "wof:parent_id":85672289,
     "wof:placetype":"county",

--- a/data/110/872/007/7/1108720077.geojson
+++ b/data/110/872/007/7/1108720077.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.774631,
-    "geom:area_square_m":19701256546.257492,
+    "geom:area_square_m":19701256881.350658,
     "geom:bbox":"57.185417,25.402889,59.245445,26.939594",
     "geom:latitude":26.126153,
     "geom:longitude":58.239156,
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"IR.HG.BJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120815,
-    "wof:geomhash":"78dc472be8b3f20fb583c7213ab56df6",
+    "wof:geomhash":"e86b225dc51265bdc49c916012bd9040",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108720077,
-    "wof:lastmodified":1627522220,
+    "wof:lastmodified":1695886695,
     "wof:name":"Jask",
     "wof:parent_id":85672337,
     "wof:placetype":"county",

--- a/data/110/872/007/9/1108720079.geojson
+++ b/data/110/872/007/9/1108720079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071699,
-    "geom:area_square_m":727580334.186587,
+    "geom:area_square_m":727580334.186487,
     "geom:bbox":"45.920349,34.6351262785,46.5567489762,35.095489",
     "geom:latitude":34.848357,
     "geom:longitude":46.284313,
@@ -108,9 +108,10 @@
     "wof:concordances":{
         "hasc:id":"IR.BK.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120817,
-    "wof:geomhash":"9efe939543a1d6904b3d445f4871ac17",
+    "wof:geomhash":"e82d8c291bdcd87b745501ffbb7c208f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108720079,
-    "wof:lastmodified":1566718584,
+    "wof:lastmodified":1695886122,
     "wof:name":"Javanrud",
     "wof:parent_id":85672379,
     "wof:placetype":"county",

--- a/data/110/872/008/1/1108720081.geojson
+++ b/data/110/872/008/1/1108720081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.789123,
-    "geom:area_square_m":8547319528.851454,
+    "geom:area_square_m":8547319528.850595,
     "geom:bbox":"56.8962239308,28.2980660159,58.2026365575,29.3583445352",
     "geom:latitude":28.840357,
     "geom:longitude":57.47692,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KE.JI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120818,
-    "wof:geomhash":"d1b62324d33854e17ea5e917f1a243f4",
+    "wof:geomhash":"017d33f272326d1665fd2e57b0f591d2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108720081,
-    "wof:lastmodified":1566718589,
+    "wof:lastmodified":1695886125,
     "wof:name":"Jiroft",
     "wof:parent_id":85672409,
     "wof:placetype":"county",

--- a/data/110/872/008/3/1108720083.geojson
+++ b/data/110/872/008/3/1108720083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.175403,
-    "geom:area_square_m":1689396307.300537,
+    "geom:area_square_m":1689395851.228364,
     "geom:bbox":"45.284424,38.65051,46.525085,38.993955",
     "geom:latitude":38.837979,
     "geom:longitude":45.869705,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.JO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120819,
-    "wof:geomhash":"5b509d9918218f8d3619950f7817449e",
+    "wof:geomhash":"22a3cd6d3cc69e925ffdae8af9878635",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720083,
-    "wof:lastmodified":1627522217,
+    "wof:lastmodified":1695886693,
     "wof:name":"Jolfa",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/872/008/5/1108720085.geojson
+++ b/data/110/872/008/5/1108720085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027979,
-    "geom:area_square_m":277458514.974263,
+    "geom:area_square_m":277458514.974226,
     "geom:bbox":"52.8110560591,36.5729707659,53.0057356674,36.7841171403",
     "geom:latitude":36.678918,
     "geom:longitude":52.914219,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MN.JB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120820,
-    "wof:geomhash":"a515caa939f648d6d3160815a218839c",
+    "wof:geomhash":"0056b8537f88aa50e68c2f3e16ee416d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108720085,
-    "wof:lastmodified":1566718589,
+    "wof:lastmodified":1695886125,
     "wof:name":"Juybar",
     "wof:parent_id":85672303,
     "wof:placetype":"county",

--- a/data/110/872/008/7/1108720087.geojson
+++ b/data/110/872/008/7/1108720087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.381434,
-    "geom:area_square_m":3846081970.002363,
+    "geom:area_square_m":3846081689.580892,
     "geom:bbox":"47.866171,34.956844,48.917764,35.720898",
     "geom:latitude":35.367701,
     "geom:longitude":48.38243,
@@ -133,9 +133,10 @@
         "hasc:id":"IR.HD.KA",
         "wd:id":"Q1286111"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120822,
-    "wof:geomhash":"9ed1e45552cfd56f92022692a33e6b82",
+    "wof:geomhash":"86646e46c163e31826191138dce9a283",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108720087,
-    "wof:lastmodified":1690934528,
+    "wof:lastmodified":1695886125,
     "wof:name":"Kabudarahang",
     "wof:parent_id":85672355,
     "wof:placetype":"county",

--- a/data/110/872/009/1/1108720091.geojson
+++ b/data/110/872/009/1/1108720091.geojson
@@ -80,6 +80,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KE.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120823,
     "wof:geomhash":"98a334d78248625f103a20001c541f2f",
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108720091,
-    "wof:lastmodified":1694498049,
+    "wof:lastmodified":1695886696,
     "wof:name":"Kahnuj",
     "wof:parent_id":85672409,
     "wof:placetype":"county",

--- a/data/110/872/009/3/1108720093.geojson
+++ b/data/110/872/009/3/1108720093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.505383,
-    "geom:area_square_m":4941454293.308331,
+    "geom:area_square_m":4941454445.135345,
     "geom:bbox":"55.298497,37.323087,56.31376,38.127798",
     "geom:latitude":37.744978,
     "geom:longitude":55.791873,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GO.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120824,
-    "wof:geomhash":"8fb7be69eea3a362779ba38408495481",
+    "wof:geomhash":"1a1ca367d2ec2baf522983c6eeba04e9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720093,
-    "wof:lastmodified":1627522220,
+    "wof:lastmodified":1695886696,
     "wof:name":"Kalaleh",
     "wof:parent_id":85672299,
     "wof:placetype":"county",

--- a/data/110/872/009/5/1108720095.geojson
+++ b/data/110/872/009/5/1108720095.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.KL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120825,
     "wof:geomhash":"71a578b30da8f633063724041687340d",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108720095,
-    "wof:lastmodified":1694498049,
+    "wof:lastmodified":1695886696,
     "wof:name":"Kalat",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/872/009/7/1108720097.geojson
+++ b/data/110/872/009/7/1108720097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.38481,
-    "geom:area_square_m":3698187671.228679,
+    "geom:area_square_m":3698187808.756938,
     "geom:bbox":"46.457386,38.615666,47.520469,39.426777",
     "geom:latitude":38.99325,
     "geom:longitude":47.057891,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120827,
-    "wof:geomhash":"3597561a415fab81d6d3e25b2d50eb51",
+    "wof:geomhash":"d91b76ca2b39260fd0586bbac473c9d0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720097,
-    "wof:lastmodified":1627522220,
+    "wof:lastmodified":1695886696,
     "wof:name":"Kaleibar",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/872/009/9/1108720099.geojson
+++ b/data/110/872/009/9/1108720099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.202583,
-    "geom:area_square_m":2053028388.760054,
+    "geom:area_square_m":2053029015.561452,
     "geom:bbox":"46.500857,34.740806,47.332607,35.165907",
     "geom:latitude":34.957084,
     "geom:longitude":46.91401,
@@ -117,9 +117,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KD.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120828,
-    "wof:geomhash":"f2889e6aceaa352628af3c1b12569245",
+    "wof:geomhash":"589249bcf03674d472b7c424a172f479",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108720099,
-    "wof:lastmodified":1627522220,
+    "wof:lastmodified":1695886696,
     "wof:name":"Kamyaran",
     "wof:parent_id":85672387,
     "wof:placetype":"county",

--- a/data/110/872/010/1/1108720101.geojson
+++ b/data/110/872/010/1/1108720101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.107528,
-    "geom:area_square_m":1178622087.712631,
+    "geom:area_square_m":1178622101.506125,
     "geom:bbox":"52.001613,27.272055,52.940308,27.936335",
     "geom:latitude":27.569813,
     "geom:longitude":52.514434,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"IR.BS.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120829,
-    "wof:geomhash":"489902995ba603be52c74d1d227ef2e2",
+    "wof:geomhash":"dc2a469b3e37d2f58760ad853880eb4b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108720101,
-    "wof:lastmodified":1627522220,
+    "wof:lastmodified":1695886696,
     "wof:name":"Kangan",
     "wof:parent_id":85672289,
     "wof:placetype":"county",

--- a/data/110/872/010/3/1108720103.geojson
+++ b/data/110/872/010/3/1108720103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086738,
-    "geom:area_square_m":884146457.347886,
+    "geom:area_square_m":884146276.103346,
     "geom:bbox":"47.715487,34.258018,48.1037,34.647351",
     "geom:latitude":34.476949,
     "geom:longitude":47.916214,
@@ -148,9 +148,10 @@
         "hasc:id":"IR.BK.KA",
         "wd:id":"Q1289742"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120830,
-    "wof:geomhash":"4bc6f3b0626319ee6b18b0be1d315c53",
+    "wof:geomhash":"f7a9f98505a7384bdf5cdd1f3fa05f84",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1108720103,
-    "wof:lastmodified":1690934534,
+    "wof:lastmodified":1695886129,
     "wof:name":"Kangavar",
     "wof:parent_id":85672379,
     "wof:placetype":"county",

--- a/data/110/872/010/5/1108720105.geojson
+++ b/data/110/872/010/5/1108720105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.222069,
-    "geom:area_square_m":2225192921.213811,
+    "geom:area_square_m":2225192921.213814,
     "geom:bbox":"50.1635514356,35.5434141256,51.4633222186,36.1834370059",
     "geom:latitude":35.868429,
     "geom:longitude":50.896227,
@@ -255,9 +255,10 @@
     "wof:concordances":{
         "hasc:id":"IR.AL.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120832,
-    "wof:geomhash":"f77d95ae5327c039efb3bbdcd06ab8eb",
+    "wof:geomhash":"82a6bcc04723f470fbd8ee3e8fd22488",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -267,7 +268,7 @@
         }
     ],
     "wof:id":1108720105,
-    "wof:lastmodified":1566718599,
+    "wof:lastmodified":1695886129,
     "wof:name":"Karaj",
     "wof:parent_id":85672415,
     "wof:placetype":"county",

--- a/data/110/872/010/9/1108720109.geojson
+++ b/data/110/872/010/9/1108720109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.431326,
-    "geom:area_square_m":4425566607.795537,
+    "geom:area_square_m":4425567218.913753,
     "geom:bbox":"50.911213,33.496651,51.81847,34.447187",
     "geom:latitude":33.923158,
     "geom:longitude":51.278349,
@@ -198,9 +198,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120833,
-    "wof:geomhash":"b8c53229f75afa223632e3c93d90081f",
+    "wof:geomhash":"1f7d102d831ebf170ff7ab6a49243f41",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -210,7 +211,7 @@
         }
     ],
     "wof:id":1108720109,
-    "wof:lastmodified":1636495416,
+    "wof:lastmodified":1695886651,
     "wof:name":"Kashan",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/872/011/1/1108720111.geojson
+++ b/data/110/872/011/1/1108720111.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.273562,
-    "geom:area_square_m":2756677628.997951,
+    "geom:area_square_m":2756678412.363006,
     "geom:bbox":"58.160775,35.093566,58.81091,35.734024",
     "geom:latitude":35.41743,
     "geom:longitude":58.492951,
@@ -174,9 +174,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120834,
-    "wof:geomhash":"c9ba6395715e053c053fa7004b577af6",
+    "wof:geomhash":"ec52557c0043a38b84a967de66fba7d6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":1108720111,
-    "wof:lastmodified":1636495416,
+    "wof:lastmodified":1695886652,
     "wof:name":"Kashmar",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/872/011/3/1108720113.geojson
+++ b/data/110/872/011/3/1108720113.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.379869,
-    "geom:area_square_m":4087388007.071278,
+    "geom:area_square_m":4087388007.071172,
     "geom:bbox":"51.2706046285,29.0903291317,52.1420581654,29.9137041849",
     "geom:latitude":29.519399,
     "geom:longitude":51.7146,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120836,
-    "wof:geomhash":"ba228f2bceb523d68cd4492b02a170c4",
+    "wof:geomhash":"7c441d4f404fd22625568ba82f0820b8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108720113,
-    "wof:lastmodified":1566718595,
+    "wof:lastmodified":1695886128,
     "wof:name":"Kazerun",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/872/011/5/1108720115.geojson
+++ b/data/110/872/011/5/1108720115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.215782,
-    "geom:area_square_m":44983927475.308006,
+    "geom:area_square_m":44983927448.823631,
     "geom:bbox":"56.251712,29.273579,59.467308,31.760959",
     "geom:latitude":30.347969,
     "geom:longitude":58.131893,
@@ -145,9 +145,10 @@
         "hasc:id":"IR.KE.KE",
         "wd:id":"Q1286434"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120837,
-    "wof:geomhash":"e302c4dabb342ed8e700b3f35dce8660",
+    "wof:geomhash":"3b11f3f5035d32bfeabbc341f4c21205",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108720115,
-    "wof:lastmodified":1690934532,
+    "wof:lastmodified":1695886128,
     "wof:name":"Kerman",
     "wof:parent_id":85672409,
     "wof:placetype":"county",

--- a/data/110/872/011/7/1108720117.geojson
+++ b/data/110/872/011/7/1108720117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.56222,
-    "geom:area_square_m":5743107673.808398,
+    "geom:area_square_m":5743107964.521198,
     "geom:bbox":"46.428953,33.788202,47.497327,34.805571",
     "geom:latitude":34.29776,
     "geom:longitude":47.012639,
@@ -157,9 +157,10 @@
         "hasc:id":"IR.BK.KE",
         "wd:id":"Q1289717"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120838,
-    "wof:geomhash":"d42225b5dbd663d1d455c0dca5ef52e3",
+    "wof:geomhash":"c17b02157d270e56c309ffc82ec6135e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -169,7 +170,7 @@
         }
     ],
     "wof:id":1108720117,
-    "wof:lastmodified":1690934532,
+    "wof:lastmodified":1695886651,
     "wof:name":"Kermanshah",
     "wof:parent_id":85672379,
     "wof:placetype":"county",

--- a/data/110/872/011/9/1108720119.geojson
+++ b/data/110/872/011/9/1108720119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.959176,
-    "geom:area_square_m":9784772065.061197,
+    "geom:area_square_m":9784771882.958012,
     "geom:bbox":"59.38368,33.857637,60.918373,35.041267",
     "geom:latitude":34.411188,
     "geom:longitude":60.036192,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120839,
-    "wof:geomhash":"28ab007eee9624c72131633ee6bb477d",
+    "wof:geomhash":"fb8b4eb71704c41a5877c7c31ccef07e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720119,
-    "wof:lastmodified":1627522221,
+    "wof:lastmodified":1695886696,
     "wof:name":"Khaf",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/872/012/1/1108720121.geojson
+++ b/data/110/872/012/1/1108720121.geojson
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":1108720121,
-    "wof:lastmodified":1694498050,
+    "wof:lastmodified":1695886696,
     "wof:name":"Khalil Abad",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/872/012/3/1108720123.geojson
+++ b/data/110/872/012/3/1108720123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.285662,
-    "geom:area_square_m":2804973262.149998,
+    "geom:area_square_m":2804973195.520199,
     "geom:bbox":"48.145964,37.105482,48.921819,37.873114",
     "geom:latitude":37.429397,
     "geom:longitude":48.542141,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"IR.AR.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120842,
-    "wof:geomhash":"a71cd5f9954f499221023fdebfa87ba4",
+    "wof:geomhash":"2c29f3cb23d22efbbb35657346b2ad01",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108720123,
-    "wof:lastmodified":1627522221,
+    "wof:lastmodified":1695886696,
     "wof:name":"Khalkhal",
     "wof:parent_id":85672343,
     "wof:placetype":"county",

--- a/data/110/872/012/7/1108720127.geojson
+++ b/data/110/872/012/7/1108720127.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"IR.HG.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120843,
     "wof:geomhash":"d94ba9854e926a5ff65a445fc8669a8c",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108720127,
-    "wof:lastmodified":1694498049,
+    "wof:lastmodified":1695886692,
     "wof:name":"Khamir",
     "wof:parent_id":85672337,
     "wof:placetype":"county",

--- a/data/110/872/012/9/1108720129.geojson
+++ b/data/110/872/012/9/1108720129.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092615,
-    "geom:area_square_m":957686297.942547,
+    "geom:area_square_m":957686133.863032,
     "geom:bbox":"50.035772,33.080684,50.692769,33.417184",
     "geom:latitude":33.25277,
     "geom:longitude":50.380033,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120844,
-    "wof:geomhash":"106eaf771ab3825069bd373136455e36",
+    "wof:geomhash":"bbcb495ce37d11f33d38aee6dd35395f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108720129,
-    "wof:lastmodified":1627522221,
+    "wof:lastmodified":1695886697,
     "wof:name":"Khansar",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/872/013/1/1108720131.geojson
+++ b/data/110/872/013/1/1108720131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.801764,
-    "geom:area_square_m":19635716159.015053,
+    "geom:area_square_m":19635715809.53421,
     "geom:bbox":"60.189436,27.457345,62.794417,28.895228",
     "geom:latitude":28.19323,
     "geom:longitude":61.283133,
@@ -148,9 +148,10 @@
         "hasc:id":"IR.SB.KH",
         "wd:id":"Q1278689"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120846,
-    "wof:geomhash":"c9bc1119bee374627a92cf06f96486aa",
+    "wof:geomhash":"cdf5b40ce2f4968efae9e6e5c47ddecf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1108720131,
-    "wof:lastmodified":1690934448,
+    "wof:lastmodified":1695886119,
     "wof:name":"Khash",
     "wof:parent_id":85672405,
     "wof:placetype":"county",

--- a/data/110/872/013/3/1108720133.geojson
+++ b/data/110/872/013/3/1108720133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.766496,
-    "geom:area_square_m":8177679934.243123,
+    "geom:area_square_m":8177679934.244035,
     "geom:bbox":"53.8381898796,29.5971317931,54.5657817436,31.0132810797",
     "geom:latitude":30.363256,
     "geom:longitude":54.238686,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"IR.YA.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120848,
-    "wof:geomhash":"9bf95f7889e7e33cfbca8780b1e56a5d",
+    "wof:geomhash":"9c7739832e2e685f9ff2a0eb71ee08ef",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108720133,
-    "wof:lastmodified":1566718580,
+    "wof:lastmodified":1695886120,
     "wof:name":"Khatam",
     "wof:parent_id":85672317,
     "wof:placetype":"county",

--- a/data/110/872/013/5/1108720135.geojson
+++ b/data/110/872/013/5/1108720135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.511669,
-    "geom:area_square_m":5119197814.397257,
+    "geom:area_square_m":5119198126.287679,
     "geom:bbox":"47.857127,35.551784,48.952359,36.423815",
     "geom:latitude":35.989779,
     "geom:longitude":48.482806,
@@ -142,9 +142,10 @@
         "hasc:id":"IR.ZA.KH",
         "wd:id":"Q1286131"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120849,
-    "wof:geomhash":"b2778daadf05c23e442e8f12db69858e",
+    "wof:geomhash":"6d7898f69ebb26fcc22c026e83767f3b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108720135,
-    "wof:lastmodified":1690934448,
+    "wof:lastmodified":1695886120,
     "wof:name":"Khodabandeh",
     "wof:parent_id":85672361,
     "wof:placetype":"county",

--- a/data/110/872/013/7/1108720137.geojson
+++ b/data/110/872/013/7/1108720137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.232567,
-    "geom:area_square_m":2393354934.232017,
+    "geom:area_square_m":2393355199.993286,
     "geom:bbox":"49.595,33.385009,50.452573,33.942163",
     "geom:latitude":33.668457,
     "geom:longitude":49.996664,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MK.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120850,
-    "wof:geomhash":"8b63450aad53571debaf6166ac6b9f94",
+    "wof:geomhash":"bba65feed224d8201e10bcbf190e2b45",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720137,
-    "wof:lastmodified":1627522221,
+    "wof:lastmodified":1695886697,
     "wof:name":"Khomein",
     "wof:parent_id":85672347,
     "wof:placetype":"county",

--- a/data/110/872/013/9/1108720139.geojson
+++ b/data/110/872/013/9/1108720139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019206,
-    "geom:area_square_m":199891841.145666,
+    "geom:area_square_m":199892013.41637,
     "geom:bbox":"51.41361,32.595077,51.631479,32.771446",
     "geom:latitude":32.682119,
     "geom:longitude":51.51924,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120851,
-    "wof:geomhash":"06d1b5d3a4bf6c33d2a426f40ff8e5b7",
+    "wof:geomhash":"e74ec546a133fe05359a9901848973cf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720139,
-    "wof:lastmodified":1627522221,
+    "wof:lastmodified":1695886697,
     "wof:name":"Khomeinishahr",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/872/014/1/1108720141.geojson
+++ b/data/110/872/014/1/1108720141.geojson
@@ -92,6 +92,7 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.LR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120852,
     "wof:geomhash":"115173437f6a88fc61cb75f832cc9cb4",
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108720141,
-    "wof:lastmodified":1694498050,
+    "wof:lastmodified":1695886697,
     "wof:name":"Khonj",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/872/014/5/1108720145.geojson
+++ b/data/110/872/014/5/1108720145.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.616065,
-    "geom:area_square_m":6356795953.597019,
+    "geom:area_square_m":6356795806.417552,
     "geom:bbox":"47.628501,32.897227,48.998176,33.905113",
     "geom:latitude":33.438694,
     "geom:longitude":48.437478,
@@ -145,9 +145,10 @@
         "hasc:id":"IR.LO.KH",
         "wd:id":"Q1279146"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120853,
-    "wof:geomhash":"1bf3416d1697cf906ca30654566906d8",
+    "wof:geomhash":"70fe9545413adc1bcc0d00b4f121e675",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108720145,
-    "wof:lastmodified":1690934448,
+    "wof:lastmodified":1695886120,
     "wof:name":"Khorramabad",
     "wof:parent_id":85672329,
     "wof:placetype":"county",

--- a/data/110/872/014/7/1108720147.geojson
+++ b/data/110/872/014/7/1108720147.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120855,
     "wof:geomhash":"dd8cda2651495dbacef11a60b2584818",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108720147,
-    "wof:lastmodified":1694498050,
+    "wof:lastmodified":1695886697,
     "wof:name":"Khorrambid",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/872/014/9/1108720149.geojson
+++ b/data/110/872/014/9/1108720149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045987,
-    "geom:area_square_m":458456449.296047,
+    "geom:area_square_m":458456421.99342,
     "geom:bbox":"48.93966,36.158053,49.303171,36.43609",
     "geom:latitude":36.270508,
     "geom:longitude":49.150857,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ZA.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120856,
-    "wof:geomhash":"1e1331684c9f61c4b35471654e8d0d1f",
+    "wof:geomhash":"a1c00d4fed28e97fae4d6e4183b59d01",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108720149,
-    "wof:lastmodified":1627522221,
+    "wof:lastmodified":1695886697,
     "wof:name":"Khorramdarreh",
     "wof:parent_id":85672361,
     "wof:placetype":"county",

--- a/data/110/872/015/1/1108720151.geojson
+++ b/data/110/872/015/1/1108720151.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.187958,
-    "geom:area_square_m":1998267124.408177,
+    "geom:area_square_m":1998267124.407514,
     "geom:bbox":"48.0244455,30.315324,48.4707864034,30.9854553854",
     "geom:latitude":30.706742,
     "geom:longitude":48.205989,
@@ -165,9 +165,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120857,
-    "wof:geomhash":"2a51356c6e297b20b2f285fec1069357",
+    "wof:geomhash":"1750620a3dd5399ce20b9ab9a6c862b7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -177,7 +178,7 @@
         }
     ],
     "wof:id":1108720151,
-    "wof:lastmodified":1566718576,
+    "wof:lastmodified":1695886119,
     "wof:name":"Khorramshahr",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/872/015/3/1108720153.geojson
+++ b/data/110/872/015/3/1108720153.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.566432,
-    "geom:area_square_m":5469514465.769496,
+    "geom:area_square_m":5469515083.308506,
     "geom:bbox":"44.254067,38.322063,45.360435,39.007622",
     "geom:latitude":38.655881,
     "geom:longitude":44.811502,
@@ -142,9 +142,10 @@
         "hasc:id":"IR.WA.KH",
         "wd:id":"Q1282135"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120858,
-    "wof:geomhash":"ffc2e66da7eb5d16980505018bcac57d",
+    "wof:geomhash":"44d25907892b96dac413668467e341dd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108720153,
-    "wof:lastmodified":1690934446,
+    "wof:lastmodified":1695886119,
     "wof:name":"Khoy",
     "wof:parent_id":85672369,
     "wof:placetype":"county",

--- a/data/110/872/015/5/1108720155.geojson
+++ b/data/110/872/015/5/1108720155.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KE.RV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120860,
     "wof:geomhash":"4b8cbbbb3015363209c0c137dd8509d5",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108720155,
-    "wof:lastmodified":1694498050,
+    "wof:lastmodified":1695886697,
     "wof:name":"Kohbonan",
     "wof:parent_id":85672409,
     "wof:placetype":"county",

--- a/data/110/872/015/7/1108720157.geojson
+++ b/data/110/872/015/7/1108720157.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KB.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120861,
     "wof:geomhash":"bb7d8e92a2a22641654add255f96bb54",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108720157,
-    "wof:lastmodified":1694498050,
+    "wof:lastmodified":1695886697,
     "wof:name":"Kohgiluyeh",
     "wof:parent_id":85672283,
     "wof:placetype":"county",

--- a/data/110/872/015/9/1108720159.geojson
+++ b/data/110/872/015/9/1108720159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.155157,
-    "geom:area_square_m":1576640099.799651,
+    "geom:area_square_m":1576639822.255998,
     "geom:bbox":"49.101367,34.527144,49.644168,34.961196",
     "geom:latitude":34.735586,
     "geom:longitude":49.35818,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MK.KJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120862,
-    "wof:geomhash":"ea8628d06fe3d413d32eb4bada22e87c",
+    "wof:geomhash":"9a750c360bc37b6bf71fd1052a588c63",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720159,
-    "wof:lastmodified":1627522221,
+    "wof:lastmodified":1695886697,
     "wof:name":"Komeijan",
     "wof:parent_id":85672347,
     "wof:placetype":"county",

--- a/data/110/872/016/3/1108720163.geojson
+++ b/data/110/872/016/3/1108720163.geojson
@@ -62,6 +62,7 @@
     "wof:concordances":{
         "hasc:id":"IR.SB.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120863,
     "wof:geomhash":"b4f34ff84817d60ae49ed66be8957746",
@@ -74,7 +75,7 @@
         }
     ],
     "wof:id":1108720163,
-    "wof:lastmodified":1694498050,
+    "wof:lastmodified":1695886697,
     "wof:name":"Konarak",
     "wof:parent_id":85672405,
     "wof:placetype":"county",

--- a/data/110/872/016/5/1108720165.geojson
+++ b/data/110/872/016/5/1108720165.geojson
@@ -95,6 +95,7 @@
     "wof:concordances":{
         "hasc:id":"IR.GO.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120864,
     "wof:geomhash":"81525607a43e3f883d2c9ee5de52a4da",
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108720165,
-    "wof:lastmodified":1694498050,
+    "wof:lastmodified":1695886697,
     "wof:name":"Kordkuy",
     "wof:parent_id":85672299,
     "wof:placetype":"county",

--- a/data/110/872/016/7/1108720167.geojson
+++ b/data/110/872/016/7/1108720167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.129969,
-    "geom:area_square_m":1271252181.054715,
+    "geom:area_square_m":1271252181.054605,
     "geom:bbox":"48.0198529283,37.4607637106,48.5820670313,37.9703940697",
     "geom:latitude":37.718054,
     "geom:longitude":48.27549,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"IR.AR.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120866,
-    "wof:geomhash":"616a281bbf299ba8927001b24e426819",
+    "wof:geomhash":"145c639a575f64459d5f456a4525cf2e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108720167,
-    "wof:lastmodified":1566718595,
+    "wof:lastmodified":1695886128,
     "wof:name":"Kowsar",
     "wof:parent_id":85672343,
     "wof:placetype":"county",

--- a/data/110/872/016/9/1108720169.geojson
+++ b/data/110/872/016/9/1108720169.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.390228,
-    "geom:area_square_m":4023429047.063688,
+    "geom:area_square_m":4023429047.063484,
     "geom:bbox":"46.839931524,33.1459233531,47.8552229246,33.8750211699",
     "geom:latitude":33.50559,
     "geom:longitude":47.393418,
@@ -111,9 +111,10 @@
     "wof:concordances":{
         "hasc:id":"IR.LO.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120867,
-    "wof:geomhash":"1ed5b4ebd840756bc518e2d61637a8cd",
+    "wof:geomhash":"ab8a3fdf048fd09623cdc0e04e9a70af",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108720169,
-    "wof:lastmodified":1566718595,
+    "wof:lastmodified":1695886128,
     "wof:name":"Kuhdasht",
     "wof:parent_id":85672329,
     "wof:placetype":"county",

--- a/data/110/872/017/1/1108720171.geojson
+++ b/data/110/872/017/1/1108720171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.356937,
-    "geom:area_square_m":3725594023.465854,
+    "geom:area_square_m":3725594642.509409,
     "geom:bbox":"49.501521,32.000236,50.43647,32.807761",
     "geom:latitude":32.421881,
     "geom:longitude":50.033695,
@@ -139,9 +139,10 @@
         "hasc:id":"IR.CM.KU",
         "wd:id":"Q1279066"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120868,
-    "wof:geomhash":"d96101d48cd8f8d0f1ae3caf0fd8b45f",
+    "wof:geomhash":"ce370bf321cbff6651effdfab5b9ab9c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108720171,
-    "wof:lastmodified":1690934533,
+    "wof:lastmodified":1695886129,
     "wof:name":"Kuhrang",
     "wof:parent_id":85672319,
     "wof:placetype":"county",

--- a/data/110/872/017/3/1108720173.geojson
+++ b/data/110/872/017/3/1108720173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041074,
-    "geom:area_square_m":404424419.078084,
+    "geom:area_square_m":404424272.28531,
     "geom:bbox":"49.777772,37.091128,50.228726,37.390288",
     "geom:latitude":37.223614,
     "geom:longitude":50.037471,
@@ -145,9 +145,10 @@
         "hasc:id":"IR.GI.LA",
         "wd:id":"Q1289706"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120869,
-    "wof:geomhash":"fbb418a90c1f750b8908fa5998f10da7",
+    "wof:geomhash":"b0556056cf751f9480d0740ff95f7e19",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108720173,
-    "wof:lastmodified":1690934534,
+    "wof:lastmodified":1695886129,
     "wof:name":"Lahijan",
     "wof:parent_id":85672383,
     "wof:placetype":"county",

--- a/data/110/872/017/5/1108720175.geojson
+++ b/data/110/872/017/5/1108720175.geojson
@@ -233,6 +233,7 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120871,
     "wof:geomhash":"7ba695656ddfc13011ab7a3deadd5581",
@@ -245,7 +246,7 @@
         }
     ],
     "wof:id":1108720175,
-    "wof:lastmodified":1694498101,
+    "wof:lastmodified":1695886652,
     "wof:name":"Lake Urmia",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/872/017/7/1108720177.geojson
+++ b/data/110/872/017/7/1108720177.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134044,
-    "geom:area_square_m":1399019200.902235,
+    "geom:area_square_m":1399019200.902265,
     "geom:bbox":"48.9188527953,32.1879694521,49.4288195631,32.6103535973",
     "geom:latitude":32.428188,
     "geom:longitude":49.175585,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120872,
-    "wof:geomhash":"952b08b74ec2f3b35fef62b2f7fbb4e0",
+    "wof:geomhash":"64a091f3db595f0b18e00e2553f5f338",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108720177,
-    "wof:lastmodified":1566718597,
+    "wof:lastmodified":1695886129,
     "wof:name":"Lali",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/872/018/1/1108720181.geojson
+++ b/data/110/872/018/1/1108720181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.35807,
-    "geom:area_square_m":3930598354.848755,
+    "geom:area_square_m":3930598354.849079,
     "geom:bbox":"52.6366725162,27.04597344,54.0344702708,27.8887288442",
     "geom:latitude":27.407648,
     "geom:longitude":53.346044,
@@ -105,9 +105,10 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.LD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120873,
-    "wof:geomhash":"cb89b06094dda934198a5b04bd1a7870",
+    "wof:geomhash":"c585e162d0ffa53750631d5a37cb0fa3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108720181,
-    "wof:lastmodified":1566718594,
+    "wof:lastmodified":1695886127,
     "wof:name":"Lamerd",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/872/018/3/1108720183.geojson
+++ b/data/110/872/018/3/1108720183.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047061,
-    "geom:area_square_m":463982985.150363,
+    "geom:area_square_m":463983187.818494,
     "geom:bbox":"49.936068,36.962465,50.283816,37.30021",
     "geom:latitude":37.124411,
     "geom:longitude":50.111505,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GI.LG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120875,
-    "wof:geomhash":"7c969a5a493f60f3d5ea0545c5a900c6",
+    "wof:geomhash":"9d1bc533f03a85de5cad37d1df08458c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720183,
-    "wof:lastmodified":1627522222,
+    "wof:lastmodified":1695886698,
     "wof:name":"Langrud",
     "wof:parent_id":85672383,
     "wof:placetype":"county",

--- a/data/110/872/018/5/1108720185.geojson
+++ b/data/110/872/018/5/1108720185.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.LR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120876,
     "wof:geomhash":"7a2c0baddbb0dd11b3356397bb39285b",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108720185,
-    "wof:lastmodified":1694498050,
+    "wof:lastmodified":1695886698,
     "wof:name":"Larestan",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/872/018/7/1108720187.geojson
+++ b/data/110/872/018/7/1108720187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.112931,
-    "geom:area_square_m":1178948253.724711,
+    "geom:area_square_m":1178948078.926948,
     "geom:bbox":"50.966753,32.188539,51.470251,32.587902",
     "geom:latitude":32.406433,
     "geom:longitude":51.225501,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120877,
-    "wof:geomhash":"58c4496a6f55d43b70fa9823c492c0c7",
+    "wof:geomhash":"5c196000429f2c4ccd4f8e67e467d80f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108720187,
-    "wof:lastmodified":1627522222,
+    "wof:lastmodified":1695886698,
     "wof:name":"Lenjan",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/872/018/9/1108720189.geojson
+++ b/data/110/872/018/9/1108720189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.309442,
-    "geom:area_square_m":3263769246.192339,
+    "geom:area_square_m":3263769246.192551,
     "geom:bbox":"50.2937487632,31.1505362186,51.3381951744,31.7594361647",
     "geom:latitude":31.462428,
     "geom:longitude":50.886009,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"IR.CM.LO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120878,
-    "wof:geomhash":"fb8bce90e9bdd559d2af79cc55a1dec6",
+    "wof:geomhash":"9190c70d951aa9090747a0ea55a490b1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108720189,
-    "wof:lastmodified":1566718594,
+    "wof:lastmodified":1695886127,
     "wof:name":"Lordegan",
     "wof:parent_id":85672319,
     "wof:placetype":"county",

--- a/data/110/872/019/1/1108720191.geojson
+++ b/data/110/872/019/1/1108720191.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120880,
     "wof:geomhash":"c20f6611b044e18f539032788b510070",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108720191,
-    "wof:lastmodified":1694498050,
+    "wof:lastmodified":1695886698,
     "wof:name":"Mah-Velat",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/872/019/3/1108720193.geojson
+++ b/data/110/872/019/3/1108720193.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.263574,
-    "geom:area_square_m":2614293490.399734,
+    "geom:area_square_m":2614293163.004967,
     "geom:bbox":"45.439328,36.27254,46.058765,37.041745",
     "geom:latitude":36.664528,
     "geom:longitude":45.736576,
@@ -147,9 +147,10 @@
     "wof:concordances":{
         "hasc:id":"IR.WA.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120881,
-    "wof:geomhash":"999d7a82a3cef5d20e23d775fb9c2912",
+    "wof:geomhash":"71b8ac1df67b504b5b62087514cdfbfb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1108720193,
-    "wof:lastmodified":1636495416,
+    "wof:lastmodified":1695886652,
     "wof:name":"Mahabad",
     "wof:parent_id":85672369,
     "wof:placetype":"county",

--- a/data/110/872/019/5/1108720195.geojson
+++ b/data/110/872/019/5/1108720195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.193226,
-    "geom:area_square_m":1983478972.243804,
+    "geom:area_square_m":1983478972.243702,
     "geom:bbox":"50.152705829,33.6285318393,50.7596990113,34.1544904405",
     "geom:latitude":33.884945,
     "geom:longitude":50.449144,
@@ -111,9 +111,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MK.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120882,
-    "wof:geomhash":"34bb84b87cbc24401ccfbee0530bce76",
+    "wof:geomhash":"bf9156175ac241220e84cf5ed335e73e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108720195,
-    "wof:lastmodified":1566718599,
+    "wof:lastmodified":1695886129,
     "wof:name":"Mahallat",
     "wof:parent_id":85672347,
     "wof:placetype":"county",

--- a/data/110/872/019/9/1108720199.geojson
+++ b/data/110/872/019/9/1108720199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026984,
-    "geom:area_square_m":267843007.815253,
+    "geom:area_square_m":267842524.338341,
     "geom:bbox":"52.180275,36.534155,52.481588,36.684852",
     "geom:latitude":36.60739,
     "geom:longitude":52.332678,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MN.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120883,
-    "wof:geomhash":"c38e71f7f9aad2d23ab8cda654eec76a",
+    "wof:geomhash":"303b12f7be07af66fcdac38e3df82f90",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720199,
-    "wof:lastmodified":1627522222,
+    "wof:lastmodified":1695886698,
     "wof:name":"Mahmoudabad",
     "wof:parent_id":85672303,
     "wof:placetype":"county",

--- a/data/110/872/020/1/1108720201.geojson
+++ b/data/110/872/020/1/1108720201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.290041,
-    "geom:area_square_m":2877538449.44947,
+    "geom:area_square_m":2877538364.90823,
     "geom:bbox":"47.176611,36.329736,47.967736,36.956768",
     "geom:latitude":36.645324,
     "geom:longitude":47.580824,
@@ -136,9 +136,10 @@
         "hasc:id":"IR.ZA.MA",
         "wd:id":"Q1286221"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120884,
-    "wof:geomhash":"ca82479ca1f083e0d63197b0273bee91",
+    "wof:geomhash":"f8f7a7ff5a4843e3065b097158e7ad6a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1108720201,
-    "wof:lastmodified":1690934531,
+    "wof:lastmodified":1695886127,
     "wof:name":"Mahneshan",
     "wof:parent_id":85672361,
     "wof:placetype":"county",

--- a/data/110/872/020/3/1108720203.geojson
+++ b/data/110/872/020/3/1108720203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.45957,
-    "geom:area_square_m":4397555578.569887,
+    "geom:area_square_m":4397555855.34536,
     "geom:bbox":"44.282091,38.934806,45.456552,39.781676",
     "geom:latitude":39.298244,
     "geom:longitude":44.816541,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"IR.WA.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120885,
-    "wof:geomhash":"7c39c366251beca366b9c93471986360",
+    "wof:geomhash":"a4063ba207130ab0203bee0e9c550c87",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108720203,
-    "wof:lastmodified":1627522222,
+    "wof:lastmodified":1695886698,
     "wof:name":"Maku",
     "wof:parent_id":85672369,
     "wof:placetype":"county",

--- a/data/110/872/020/5/1108720205.geojson
+++ b/data/110/872/020/5/1108720205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.324414,
-    "geom:area_square_m":3312878173.1934,
+    "geom:area_square_m":3312878260.036807,
     "geom:bbox":"48.383157,34.00194,49.174485,34.675069",
     "geom:latitude":34.324171,
     "geom:longitude":48.793801,
@@ -169,9 +169,10 @@
         "hasc:id":"IR.HD.MA",
         "wd:id":"Q1285937"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120887,
-    "wof:geomhash":"93fb41f14d839cc04e038e55c941eff3",
+    "wof:geomhash":"0a13a84b19de0b7eec3c51bdcbce9dc8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -181,7 +182,7 @@
         }
     ],
     "wof:id":1108720205,
-    "wof:lastmodified":1690934531,
+    "wof:lastmodified":1695886651,
     "wof:name":"Malayer",
     "wof:parent_id":85672355,
     "wof:placetype":"county",

--- a/data/110/872/020/7/1108720207.geojson
+++ b/data/110/872/020/7/1108720207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090306,
-    "geom:area_square_m":890288758.951975,
+    "geom:area_square_m":890288305.319682,
     "geom:bbox":"45.916745,36.94533,46.439779,37.281612",
     "geom:latitude":37.128191,
     "geom:longitude":46.203142,
@@ -105,9 +105,10 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.ML"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120888,
-    "wof:geomhash":"496757eccadb7dbae5b4c90297305bdd",
+    "wof:geomhash":"5aef1dfb77601fb58cc521729c0319e3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108720207,
-    "wof:lastmodified":1627522222,
+    "wof:lastmodified":1695886698,
     "wof:name":"Malekan",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/872/020/9/1108720209.geojson
+++ b/data/110/872/020/9/1108720209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.622542,
-    "geom:area_square_m":6661596822.012045,
+    "geom:area_square_m":6661597720.982891,
     "geom:bbox":"50.606156,29.695605,52.128776,30.655126",
     "geom:latitude":30.072872,
     "geom:longitude":51.375653,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.MM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120890,
-    "wof:geomhash":"a7109b625e8543ec48bce241735493ce",
+    "wof:geomhash":"516041d02ec26e4e5f1ad17ba073995a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108720209,
-    "wof:lastmodified":1627522228,
+    "wof:lastmodified":1695886703,
     "wof:name":"Mamasani",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/872/021/1/1108720211.geojson
+++ b/data/110/872/021/1/1108720211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.614651,
-    "geom:area_square_m":6015085217.437578,
+    "geom:area_square_m":6015085472.99303,
     "geom:bbox":"55.995919,37.305108,57.281043,38.154741",
     "geom:latitude":37.680245,
     "geom:longitude":56.589778,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KS.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120891,
-    "wof:geomhash":"cde396810b2474ff1d4dd56af82cc5d7",
+    "wof:geomhash":"24e178a4fb4f749eb845ec1a710926cf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720211,
-    "wof:lastmodified":1627522222,
+    "wof:lastmodified":1695886698,
     "wof:name":"Maneh and Samalqan",
     "wof:parent_id":85672401,
     "wof:placetype":"county",

--- a/data/110/872/021/3/1108720213.geojson
+++ b/data/110/872/021/3/1108720213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.405546,
-    "geom:area_square_m":4452628034.800379,
+    "geom:area_square_m":4452628194.800653,
     "geom:bbox":"57.218264,26.932278,58.132654,27.806841",
     "geom:latitude":27.385919,
     "geom:longitude":57.662852,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KE.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120892,
-    "wof:geomhash":"558bcefe66802c18fa8e57e9b9be7031",
+    "wof:geomhash":"e588e8d878946fc90368e5f25d605ad7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108720213,
-    "wof:lastmodified":1627522223,
+    "wof:lastmodified":1695886698,
     "wof:name":"Manujan",
     "wof:parent_id":85672409,
     "wof:placetype":"county",

--- a/data/110/872/021/7/1108720217.geojson
+++ b/data/110/872/021/7/1108720217.geojson
@@ -179,6 +179,7 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120893,
     "wof:geomhash":"2db769f310cefab25324055d251e9cfd",
@@ -191,7 +192,7 @@
         }
     ],
     "wof:id":1108720217,
-    "wof:lastmodified":1694498101,
+    "wof:lastmodified":1695886652,
     "wof:name":"Maragheh",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/872/021/9/1108720219.geojson
+++ b/data/110/872/021/9/1108720219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.338244,
-    "geom:area_square_m":3270482358.37049,
+    "geom:area_square_m":3270482358.370728,
     "geom:bbox":"45.2035501826,38.2943872204,46.1928301438,38.8815141566",
     "geom:latitude":38.560088,
     "geom:longitude":45.656935,
@@ -132,9 +132,10 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120895,
-    "wof:geomhash":"55120ec5c6fc5493be10b2e94c7af1b1",
+    "wof:geomhash":"6b990e719a9c070508214b5f9330c2a4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108720219,
-    "wof:lastmodified":1566718599,
+    "wof:lastmodified":1695886130,
     "wof:name":"Marand",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/872/022/1/1108720221.geojson
+++ b/data/110/872/022/1/1108720221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.232094,
-    "geom:area_square_m":2334298314.950201,
+    "geom:area_square_m":2334298314.950062,
     "geom:bbox":"45.972104,35.356366822,46.7581537534,35.8189457147",
     "geom:latitude":35.572674,
     "geom:longitude":46.351415,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KD.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120896,
-    "wof:geomhash":"92435a1d8fa3fecc536ab4bfdbac74bd",
+    "wof:geomhash":"29d7fbcf387319f7494423241c8c59b2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108720221,
-    "wof:lastmodified":1566718580,
+    "wof:lastmodified":1695886121,
     "wof:name":"Marivan",
     "wof:parent_id":85672387,
     "wof:placetype":"county",

--- a/data/110/872/022/3/1108720223.geojson
+++ b/data/110/872/022/3/1108720223.geojson
@@ -116,6 +116,7 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120897,
     "wof:geomhash":"9a6ea5cd8e55d9a32d868d498a0d4709",
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108720223,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886121,
     "wof:name":"Marvdasht",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/872/022/5/1108720225.geojson
+++ b/data/110/872/022/5/1108720225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044911,
-    "geom:area_square_m":441193446.643827,
+    "geom:area_square_m":441192843.998381,
     "geom:bbox":"48.804198,37.312639,49.186233,37.481722",
     "geom:latitude":37.395902,
     "geom:longitude":49.023563,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GI.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120898,
-    "wof:geomhash":"9af3d48df5d972ec4b87073a12f95f59",
+    "wof:geomhash":"28fcc1f5f79fbd7ebed306b9a315e8ff",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108720225,
-    "wof:lastmodified":1627522223,
+    "wof:lastmodified":1695886699,
     "wof:name":"Masal",
     "wof:parent_id":85672383,
     "wof:placetype":"county",

--- a/data/110/872/022/7/1108720227.geojson
+++ b/data/110/872/022/7/1108720227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.036908,
-    "geom:area_square_m":10338881455.972231,
+    "geom:area_square_m":10338881541.815201,
     "geom:bbox":"59.068156,35.703226,60.597558,36.977586",
     "geom:latitude":36.256547,
     "geom:longitude":59.765662,
@@ -154,9 +154,10 @@
         "hasc:id":"IR.KV.MA",
         "wd:id":"Q1270617"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120899,
-    "wof:geomhash":"f79e684f09c2e073088e07ce82fec8fb",
+    "wof:geomhash":"9b76f70033e49bb31157f894da73192c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":1108720227,
-    "wof:lastmodified":1690934448,
+    "wof:lastmodified":1695886121,
     "wof:name":"Mashhad",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/872/022/9/1108720229.geojson
+++ b/data/110/872/022/9/1108720229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.433051,
-    "geom:area_square_m":4534379438.656521,
+    "geom:area_square_m":4534378568.657826,
     "geom:bbox":"48.958653,31.696123,49.872383,32.651044",
     "geom:latitude":32.134482,
     "geom:longitude":49.429638,
@@ -147,9 +147,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120901,
-    "wof:geomhash":"704c8d778c00b36541d37fdc04aca80f",
+    "wof:geomhash":"b479cf1514cf123a78b3adeef7cb0ba4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1108720229,
-    "wof:lastmodified":1636495414,
+    "wof:lastmodified":1695886650,
     "wof:name":"Masjed Soleyman",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/872/023/1/1108720231.geojson
+++ b/data/110/872/023/1/1108720231.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.380335,
-    "geom:area_square_m":3932375380.775329,
+    "geom:area_square_m":3932374470.91395,
     "geom:bbox":"45.933148,32.898863,46.888876,33.622781",
     "geom:latitude":33.263066,
     "geom:longitude":46.415216,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"IR.IL.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120902,
-    "wof:geomhash":"738a09991a5379eb0fa1aec42328aeed",
+    "wof:geomhash":"b96e75197163cc5cb89503545f4647fc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108720231,
-    "wof:lastmodified":1627522223,
+    "wof:lastmodified":1695886699,
     "wof:name":"Mehran",
     "wof:parent_id":85672333,
     "wof:placetype":"county",

--- a/data/110/872/023/5/1108720235.geojson
+++ b/data/110/872/023/5/1108720235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.638059,
-    "geom:area_square_m":6738101755.237021,
+    "geom:area_square_m":6738101935.949069,
     "geom:bbox":"54.120705,31.005432,55.278648,31.755632",
     "geom:latitude":31.34611,
     "geom:longitude":54.643439,
@@ -105,9 +105,10 @@
     "wof:concordances":{
         "hasc:id":"IR.YA.MH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120903,
-    "wof:geomhash":"a65cbb19c6a5bd5db75aff278af15453",
+    "wof:geomhash":"fe87efa40d33be3d355fc6bc53e425aa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108720235,
-    "wof:lastmodified":1627522223,
+    "wof:lastmodified":1695886699,
     "wof:name":"Mehriz",
     "wof:parent_id":85672317,
     "wof:placetype":"county",

--- a/data/110/872/023/7/1108720237.geojson
+++ b/data/110/872/023/7/1108720237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.396013,
-    "geom:area_square_m":3828936348.935133,
+    "geom:area_square_m":3828936903.658717,
     "geom:bbox":"47.286104,38.182488,48.295055,38.902926",
     "geom:latitude":38.562061,
     "geom:longitude":47.76108,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.AR.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120904,
-    "wof:geomhash":"09fb411784298c578835a05870003e89",
+    "wof:geomhash":"cea1007090d511f3aa2dcfbef5665573",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720237,
-    "wof:lastmodified":1627522223,
+    "wof:lastmodified":1695886699,
     "wof:name":"Meshkinshahr",
     "wof:parent_id":85672343,
     "wof:placetype":"county",

--- a/data/110/872/023/9/1108720239.geojson
+++ b/data/110/872/023/9/1108720239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.11981,
-    "geom:area_square_m":1253260566.3962,
+    "geom:area_square_m":1253260566.39622,
     "geom:bbox":"53.5766777458,32.0770652105,54.4168749995,32.3247447045",
     "geom:latitude":32.225732,
     "geom:longitude":53.951941,
@@ -111,9 +111,10 @@
     "wof:concordances":{
         "hasc:id":"IR.YA.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120906,
-    "wof:geomhash":"361ba4c46528524f62caea9ae72da137",
+    "wof:geomhash":"5a538aa02de4acb09b700185b3713f28",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108720239,
-    "wof:lastmodified":1566718576,
+    "wof:lastmodified":1695886119,
     "wof:name":"Meybod",
     "wof:parent_id":85672317,
     "wof:placetype":"county",

--- a/data/110/872/024/1/1108720241.geojson
+++ b/data/110/872/024/1/1108720241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.20397,
-    "geom:area_square_m":2014299885.576388,
+    "geom:area_square_m":2014299885.57637,
     "geom:bbox":"45.6269918771,36.7885537384,46.8983100939,37.2325299211",
     "geom:latitude":36.998571,
     "geom:longitude":46.235563,
@@ -132,9 +132,10 @@
     "wof:concordances":{
         "hasc:id":"IR.WA.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120907,
-    "wof:geomhash":"03b82be7795a736a1f25d12082446631",
+    "wof:geomhash":"f473b6c8eb1ccb1dffd3fb16b84f9855",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108720241,
-    "wof:lastmodified":1566718575,
+    "wof:lastmodified":1695886118,
     "wof:name":"Miandoab",
     "wof:parent_id":85672369,
     "wof:placetype":"county",

--- a/data/110/872/024/3/1108720243.geojson
+++ b/data/110/872/024/3/1108720243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.679622,
-    "geom:area_square_m":7500900729.079737,
+    "geom:area_square_m":7500900729.080679,
     "geom:bbox":"56.8026563647,26.0924330558,57.8144448306,27.4446023489",
     "geom:latitude":26.799765,
     "geom:longitude":57.298868,
@@ -117,9 +117,10 @@
     "wof:concordances":{
         "hasc:id":"IR.HG.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120908,
-    "wof:geomhash":"8098add4d6961c602127546b4aa82a14",
+    "wof:geomhash":"69d76039ef054ac415567ce147a6e6ad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108720243,
-    "wof:lastmodified":1566718575,
+    "wof:lastmodified":1695886118,
     "wof:name":"Minab",
     "wof:parent_id":85672337,
     "wof:placetype":"county",

--- a/data/110/872/024/5/1108720245.geojson
+++ b/data/110/872/024/5/1108720245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.154395,
-    "geom:area_square_m":1519740959.962102,
+    "geom:area_square_m":1519740928.353405,
     "geom:bbox":"55.226663,37.011729,56.014665,37.466544",
     "geom:latitude":37.245972,
     "geom:longitude":55.582032,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GO.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120909,
-    "wof:geomhash":"3a23eb249c706483ae520791f1ebace8",
+    "wof:geomhash":"f0ea35149c39e78b875b8abe904dd23b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108720245,
-    "wof:lastmodified":1627522223,
+    "wof:lastmodified":1695886699,
     "wof:name":"Minudasht",
     "wof:parent_id":85672299,
     "wof:placetype":"county",

--- a/data/110/872/024/7/1108720247.geojson
+++ b/data/110/872/024/7/1108720247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.56935,
-    "geom:area_square_m":5587693003.135597,
+    "geom:area_square_m":5587693083.390247,
     "geom:bbox":"47.206963,37.077007,48.339168,37.892252",
     "geom:latitude":37.467627,
     "geom:longitude":47.723969,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120910,
-    "wof:geomhash":"b3f0a8cb27ee5454794a3ef4398c2a06",
+    "wof:geomhash":"54893560f417b8e17af335ff4a7da617",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720247,
-    "wof:lastmodified":1627522223,
+    "wof:lastmodified":1695886699,
     "wof:name":"Miyaneh",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/872/024/9/1108720249.geojson
+++ b/data/110/872/024/9/1108720249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.105255,
-    "geom:area_square_m":1100339979.862479,
+    "geom:area_square_m":1100340454.235245,
     "geom:bbox":"51.219944,32.07192,51.818027,32.48143",
     "geom:latitude":32.280382,
     "geom:longitude":51.510639,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120912,
-    "wof:geomhash":"b27f5f2cf50c029e839d5c7e65d3dcf1",
+    "wof:geomhash":"c83918d1b8580e530b24bd2d64c4f274",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108720249,
-    "wof:lastmodified":1627522223,
+    "wof:lastmodified":1695886699,
     "wof:name":"Mobarakeh",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/872/025/3/1108720253.geojson
+++ b/data/110/872/025/3/1108720253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.158234,
-    "geom:area_square_m":1733419086.925556,
+    "geom:area_square_m":1733419086.924876,
     "geom:bbox":"52.3678291712,27.3300414668,53.2222876987,28.0309156274",
     "geom:latitude":27.63286,
     "geom:longitude":52.761492,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120913,
-    "wof:geomhash":"99b016d080c838293c88f62973f8476c",
+    "wof:geomhash":"5e67c3bc4f5af2be37c17238040e46ad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108720253,
-    "wof:lastmodified":1566718581,
+    "wof:lastmodified":1695886121,
     "wof:name":"Mohr",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/872/025/5/1108720255.geojson
+++ b/data/110/872/025/5/1108720255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.263462,
-    "geom:area_square_m":33635942563.790291,
+    "geom:area_square_m":33635943125.456902,
     "geom:bbox":"52.596401,32.515798,55.497702,34.253371",
     "geom:latitude":33.533831,
     "geom:longitude":54.090864,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120914,
-    "wof:geomhash":"dc924adfadf265a660c17252f11f59e6",
+    "wof:geomhash":"0e71f723deccd6dce0cdfd1d50899ce7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720255,
-    "wof:lastmodified":1627522224,
+    "wof:lastmodified":1695886699,
     "wof:name":"Naeen",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/872/025/7/1108720257.geojson
+++ b/data/110/872/025/7/1108720257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.155479,
-    "geom:area_square_m":1589668590.527055,
+    "geom:area_square_m":1589668368.087938,
     "geom:bbox":"47.885415,34.001241,48.54011,34.434587",
     "geom:latitude":34.221834,
     "geom:longitude":48.244039,
@@ -145,9 +145,10 @@
         "hasc:id":"IR.HD.NA",
         "wd:id":"Q1279539"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120915,
-    "wof:geomhash":"984ae8a35da42ebdebf58b7ed61412d4",
+    "wof:geomhash":"ae5d8998a89a4aad2bd674959142cce3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108720257,
-    "wof:lastmodified":1690934449,
+    "wof:lastmodified":1695886121,
     "wof:name":"Nahavand",
     "wof:parent_id":85672355,
     "wof:placetype":"county",

--- a/data/110/872/025/9/1108720259.geojson
+++ b/data/110/872/025/9/1108720259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.442825,
-    "geom:area_square_m":25755549012.184834,
+    "geom:area_square_m":25755549802.56786,
     "geom:bbox":"58.424068,30.517222,60.862172,32.332633",
     "geom:latitude":31.495133,
     "geom:longitude":59.746712,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KJ.NB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120916,
-    "wof:geomhash":"7dbc1ca30ea491fd98e11f65babd754c",
+    "wof:geomhash":"2ec33a21c69feabd68895fd0912c685f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720259,
-    "wof:lastmodified":1627522224,
+    "wof:lastmodified":1695886700,
     "wof:name":"Nahbandan",
     "wof:parent_id":85672391,
     "wof:placetype":"county",

--- a/data/110/872/026/1/1108720261.geojson
+++ b/data/110/872/026/1/1108720261.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.230605,
-    "geom:area_square_m":2392176426.16514,
+    "geom:area_square_m":2392176426.165405,
     "geom:bbox":"50.600094582,32.4947472924,51.4931132195,33.3185202003",
     "geom:latitude":32.972563,
     "geom:longitude":51.050346,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.NJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120917,
-    "wof:geomhash":"20b84ec74b90fb3936d0e4f4c5f171e0",
+    "wof:geomhash":"2fc3538dcf48d74aa778bdd6f0202775",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108720261,
-    "wof:lastmodified":1566718599,
+    "wof:lastmodified":1695886130,
     "wof:name":"Najafabad",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/872/026/3/1108720263.geojson
+++ b/data/110/872/026/3/1108720263.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096898,
-    "geom:area_square_m":939094415.630368,
+    "geom:area_square_m":939094815.04423,
     "geom:bbox":"48.283594,38.164707,48.688543,38.613508",
     "geom:latitude":38.392063,
     "geom:longitude":48.467175,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"IR.AR.NM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120919,
-    "wof:geomhash":"0ab01128d31f926ef36b882d3bb4450f",
+    "wof:geomhash":"422a2a5c76b9bc5505f7ca17c933d7e8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108720263,
-    "wof:lastmodified":1627522224,
+    "wof:lastmodified":1695886700,
     "wof:name":"Namin",
     "wof:parent_id":85672343,
     "wof:placetype":"county",

--- a/data/110/872/026/5/1108720265.geojson
+++ b/data/110/872/026/5/1108720265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.11135,
-    "geom:area_square_m":1099950656.208077,
+    "geom:area_square_m":1099950656.208191,
     "geom:bbox":"45.2318998219,36.7547400081,45.6882083894,37.1603322882",
     "geom:latitude":36.976736,
     "geom:longitude":45.44326,
@@ -126,9 +126,10 @@
     "wof:concordances":{
         "hasc:id":"IR.WA.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120920,
-    "wof:geomhash":"45fec2e19dbe85619d39d1844b7e2ed6",
+    "wof:geomhash":"ce85b709f3e793cdfe059a698076dc91",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108720265,
-    "wof:lastmodified":1566718599,
+    "wof:lastmodified":1695886130,
     "wof:name":"Naqadeh",
     "wof:parent_id":85672369,
     "wof:placetype":"county",

--- a/data/110/872/026/7/1108720267.geojson
+++ b/data/110/872/026/7/1108720267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.33101,
-    "geom:area_square_m":3411146970.761019,
+    "geom:area_square_m":3411146970.761392,
     "geom:bbox":"51.4202186591,33.2077112713,52.3417135412,33.967751525",
     "geom:latitude":33.549064,
     "geom:longitude":51.876081,
@@ -141,9 +141,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.NT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120921,
-    "wof:geomhash":"a6494aaff8289275aefc73698c70ebf6",
+    "wof:geomhash":"743f5f41754a35829c1aa0cf0c00b31a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1108720267,
-    "wof:lastmodified":1566718599,
+    "wof:lastmodified":1695886130,
     "wof:name":"Natanz",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/872/027/1/1108720271.geojson
+++ b/data/110/872/027/1/1108720271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.812727,
-    "geom:area_square_m":20074441604.372612,
+    "geom:area_square_m":20074441386.720619,
     "geom:bbox":"58.846391,25.851797,61.257524,27.058374",
     "geom:latitude":26.414049,
     "geom:longitude":59.942636,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.SB.NI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120922,
-    "wof:geomhash":"19a7ac19fd8363f5a5fff6d64273cca8",
+    "wof:geomhash":"68cb947ac19a11204d501a839a013bcc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720271,
-    "wof:lastmodified":1627522224,
+    "wof:lastmodified":1695886700,
     "wof:name":"Neekshahr",
     "wof:parent_id":85672405,
     "wof:placetype":"county",

--- a/data/110/872/027/3/1108720273.geojson
+++ b/data/110/872/027/3/1108720273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.12409,
-    "geom:area_square_m":1209228979.308002,
+    "geom:area_square_m":1209228979.308005,
     "geom:bbox":"47.8285768189,37.8044709956,48.3689921476,38.1951364221",
     "geom:latitude":37.993242,
     "geom:longitude":48.104246,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"IR.AR.NR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120923,
-    "wof:geomhash":"8add720717ddd51648737458b79f2e57",
+    "wof:geomhash":"3b64c697f9b6d874e46aa6c635feb439",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108720273,
-    "wof:lastmodified":1566718594,
+    "wof:lastmodified":1695886128,
     "wof:name":"Neer",
     "wof:parent_id":85672343,
     "wof:placetype":"county",

--- a/data/110/872/027/5/1108720275.geojson
+++ b/data/110/872/027/5/1108720275.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134648,
-    "geom:area_square_m":1337972321.43125,
+    "geom:area_square_m":1337972333.74408,
     "geom:bbox":"53.173247,36.33052,54.022986,36.846173",
     "geom:latitude":36.523357,
     "geom:longitude":53.549177,
@@ -145,9 +145,10 @@
         "hasc:id":"IR.MN.NE",
         "wd:id":"Q1282190"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120925,
-    "wof:geomhash":"2a61410d65439e2577c52daa3b4d5556",
+    "wof:geomhash":"da0beba8a5ef53c5a93c27ef3b5e4ef1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108720275,
-    "wof:lastmodified":1690934532,
+    "wof:lastmodified":1695886128,
     "wof:name":"Neka",
     "wof:parent_id":85672303,
     "wof:placetype":"county",

--- a/data/110/872/027/7/1108720277.geojson
+++ b/data/110/872/027/7/1108720277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.996989,
-    "geom:area_square_m":10746731747.097239,
+    "geom:area_square_m":10746732297.51981,
     "geom:bbox":"53.413506,28.718061,55.2797,29.905891",
     "geom:latitude":29.337882,
     "geom:longitude":54.430361,
@@ -114,9 +114,10 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.NE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120926,
-    "wof:geomhash":"ba67c5e6daade0b76b8f1d8d1c098e52",
+    "wof:geomhash":"c50a84aceacb3186b6618e4e465c5283",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108720277,
-    "wof:lastmodified":1627522224,
+    "wof:lastmodified":1695886700,
     "wof:name":"Neyriz",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/872/027/9/1108720279.geojson
+++ b/data/110/872/027/9/1108720279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.881339,
-    "geom:area_square_m":8794120386.217537,
+    "geom:area_square_m":8794120398.739349,
     "geom:bbox":"58.104892,35.572134,59.313773,36.971064",
     "geom:latitude":36.199485,
     "geom:longitude":58.628146,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.NS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120927,
-    "wof:geomhash":"0d3669c80bd05ff257a3224b84e28826",
+    "wof:geomhash":"8f19418745b6395c3d12fefb38209880",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720279,
-    "wof:lastmodified":1627522224,
+    "wof:lastmodified":1695886700,
     "wof:name":"Neyshabur",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/872/028/1/1108720281.geojson
+++ b/data/110/872/028/1/1108720281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.170293,
-    "geom:area_square_m":1694086971.847052,
+    "geom:area_square_m":1694086714.049182,
     "geom:bbox":"51.320374,36.253471,51.936856,36.67997",
     "geom:latitude":36.436002,
     "geom:longitude":51.60545,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MN.NO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120928,
-    "wof:geomhash":"8aa771b974becc1d61c85df2b5368290",
+    "wof:geomhash":"f3b6c4fdc8e72671d3596a6d8cdfc5f4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720281,
-    "wof:lastmodified":1627522224,
+    "wof:lastmodified":1695886700,
     "wof:name":"Noshahr",
     "wof:parent_id":85672303,
     "wof:placetype":"county",

--- a/data/110/872/028/3/1108720283.geojson
+++ b/data/110/872/028/3/1108720283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.267628,
-    "geom:area_square_m":2667839277.809476,
+    "geom:area_square_m":2667839277.809463,
     "geom:bbox":"51.3304455101,36.0256679999,52.279145395,36.6168035973",
     "geom:latitude":36.276267,
     "geom:longitude":51.895126,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MN.NU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120929,
-    "wof:geomhash":"f18840c35b2a7fd7cac8f3b4dc9e9936",
+    "wof:geomhash":"05df175489f64e4cf699863498f1e453",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108720283,
-    "wof:lastmodified":1566718598,
+    "wof:lastmodified":1695886129,
     "wof:name":"Nur",
     "wof:parent_id":85672303,
     "wof:placetype":"county",

--- a/data/110/872/028/5/1108720285.geojson
+++ b/data/110/872/028/5/1108720285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.214118,
-    "geom:area_square_m":2275233953.15679,
+    "geom:area_square_m":2275234273.276129,
     "geom:bbox":"49.329409,30.44804,50.136927,31.083324",
     "geom:latitude":30.755572,
     "geom:longitude":49.74463,
@@ -105,9 +105,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.OM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120931,
-    "wof:geomhash":"10e952114a7c90b9c62d770eb5ea6afe",
+    "wof:geomhash":"b7093174a596a089bc40c784e674390f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108720285,
-    "wof:lastmodified":1627522224,
+    "wof:lastmodified":1695886700,
     "wof:name":"Omidiyeh",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/872/028/9/1108720289.geojson
+++ b/data/110/872/028/9/1108720289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.539221,
-    "geom:area_square_m":5281389514.675974,
+    "geom:area_square_m":5281388678.554708,
     "geom:bbox":"44.392219,37.1186,45.423215,38.150212",
     "geom:latitude":37.617023,
     "geom:longitude":44.925982,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.WA.OR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120932,
-    "wof:geomhash":"643357553c456d7f65c615d87f326429",
+    "wof:geomhash":"2d544bc1fde730cd8ec383213cec1a52",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720289,
-    "wof:lastmodified":1627522225,
+    "wof:lastmodified":1695886700,
     "wof:name":"Orumiyeh",
     "wof:parent_id":85672369,
     "wof:placetype":"county",

--- a/data/110/872/029/1/1108720291.geojson
+++ b/data/110/872/029/1/1108720291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117545,
-    "geom:area_square_m":1159686885.604268,
+    "geom:area_square_m":1159686786.61218,
     "geom:bbox":"44.747729,36.896194,45.257285,37.28413",
     "geom:latitude":37.071835,
     "geom:longitude":45.055792,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.WA.OS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120933,
-    "wof:geomhash":"584a82f4b483bce754f72e0e059660c1",
+    "wof:geomhash":"8f326bd37ed39eb44858456c051a9141",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720291,
-    "wof:lastmodified":1627522225,
+    "wof:lastmodified":1695886701,
     "wof:name":"Oshnaviyeh",
     "wof:parent_id":85672369,
     "wof:placetype":"county",

--- a/data/110/872/029/3/1108720293.geojson
+++ b/data/110/872/029/3/1108720293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.155358,
-    "geom:area_square_m":1516462636.851155,
+    "geom:area_square_m":1516462721.664399,
     "geom:bbox":"45.407877,37.684939,46.349568,38.046435",
     "geom:latitude":37.870685,
     "geom:longitude":45.871325,
@@ -139,9 +139,10 @@
         "hasc:id":"IR.EA.OS",
         "wd:id":"Q1291748"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120934,
-    "wof:geomhash":"b206daeed67ea278c3d7ad00bc68c206",
+    "wof:geomhash":"b963b7142af10b8fcb0e4fc64d51d703",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108720293,
-    "wof:lastmodified":1690934533,
+    "wof:lastmodified":1695886128,
     "wof:name":"Osku",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/872/029/5/1108720295.geojson
+++ b/data/110/872/029/5/1108720295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059276,
-    "geom:area_square_m":597064041.391271,
+    "geom:area_square_m":597064041.391234,
     "geom:bbox":"51.5817787241,35.2952527194,51.9354423037,35.5893085177",
     "geom:latitude":35.452663,
     "geom:longitude":51.777963,
@@ -108,9 +108,10 @@
     "wof:concordances":{
         "hasc:id":"IR.TE.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120936,
-    "wof:geomhash":"99e991524a50798b0d91de97da1d0f98",
+    "wof:geomhash":"2a9cddaf130557cde0beb7e549666daa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108720295,
-    "wof:lastmodified":1566718596,
+    "wof:lastmodified":1695886128,
     "wof:name":"Pakdasht",
     "wof:parent_id":85672313,
     "wof:placetype":"county",

--- a/data/110/872/029/7/1108720297.geojson
+++ b/data/110/872/029/7/1108720297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147143,
-    "geom:area_square_m":1404383778.604933,
+    "geom:area_square_m":1404383646.188029,
     "geom:bbox":"47.365489,39.216335,48.171723,39.708781",
     "geom:latitude":39.477518,
     "geom:longitude":47.735759,
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"IR.AR.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120937,
-    "wof:geomhash":"a444cb93fbba074762921ebff767bfb7",
+    "wof:geomhash":"6e7e061870ba4a52c20b7299d52ea268",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108720297,
-    "wof:lastmodified":1627522225,
+    "wof:lastmodified":1695886701,
     "wof:name":"Parsabad",
     "wof:parent_id":85672343,
     "wof:placetype":"county",

--- a/data/110/872/029/9/1108720299.geojson
+++ b/data/110/872/029/9/1108720299.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120938,
     "wof:geomhash":"2df4a0b7e37d822c2f78750853ec624d",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108720299,
-    "wof:lastmodified":1694498050,
+    "wof:lastmodified":1695886701,
     "wof:name":"Pasargad",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/872/030/1/1108720301.geojson
+++ b/data/110/872/030/1/1108720301.geojson
@@ -104,6 +104,7 @@
     "wof:concordances":{
         "hasc:id":"IR.BK.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120939,
     "wof:geomhash":"24a34c8889e0e60768ee654c94cea613",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108720301,
-    "wof:lastmodified":1694498050,
+    "wof:lastmodified":1695886701,
     "wof:name":"Paveh",
     "wof:parent_id":85672379,
     "wof:placetype":"county",

--- a/data/110/872/030/3/1108720303.geojson
+++ b/data/110/872/030/3/1108720303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.221382,
-    "geom:area_square_m":2195236235.588137,
+    "geom:area_square_m":2195236235.587708,
     "geom:bbox":"44.836812,36.4044,45.5623994778,36.9405228576",
     "geom:latitude":36.684557,
     "geom:longitude":45.224543,
@@ -231,9 +231,10 @@
     "wof:concordances":{
         "hasc:id":"IR.WA.PI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120941,
-    "wof:geomhash":"21da47fcc76eb886cd0055913206d40b",
+    "wof:geomhash":"874e8272d67a21c9cf3caaed6dda1363",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -243,7 +244,7 @@
         }
     ],
     "wof:id":1108720303,
-    "wof:lastmodified":1566718588,
+    "wof:lastmodified":1695886124,
     "wof:name":"Piranshahr",
     "wof:parent_id":85672369,
     "wof:placetype":"county",

--- a/data/110/872/030/7/1108720307.geojson
+++ b/data/110/872/030/7/1108720307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.372895,
-    "geom:area_square_m":3861149251.987288,
+    "geom:area_square_m":3861149116.98859,
     "geom:bbox":"47.473885,32.654549,48.412902,33.466416",
     "geom:latitude":33.133785,
     "geom:longitude":47.984631,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.LO.PO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120942,
-    "wof:geomhash":"3b9dc230a939d8b6777266349820c46b",
+    "wof:geomhash":"b98927599c8085b02630714995bb6ca0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720307,
-    "wof:lastmodified":1627522225,
+    "wof:lastmodified":1695886701,
     "wof:name":"Poldokhtar",
     "wof:parent_id":85672329,
     "wof:placetype":"county",

--- a/data/110/872/030/9/1108720309.geojson
+++ b/data/110/872/030/9/1108720309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047972,
-    "geom:area_square_m":476934576.4857,
+    "geom:area_square_m":476934487.180184,
     "geom:bbox":"52.723864,36.36751,53.040818,36.6388",
     "geom:latitude":36.48365,
     "geom:longitude":52.866189,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MN.QA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120943,
-    "wof:geomhash":"f8372e11ef2061a5f6f0a415b54a70a6",
+    "wof:geomhash":"7756b7432aae3a68155ea95774ea5924",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720309,
-    "wof:lastmodified":1627522225,
+    "wof:lastmodified":1695886701,
     "wof:name":"Qaemshahr",
     "wof:parent_id":85672303,
     "wof:placetype":"county",

--- a/data/110/872/031/1/1108720311.geojson
+++ b/data/110/872/031/1/1108720311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.192066,
-    "geom:area_square_m":1966298381.021799,
+    "geom:area_square_m":1966298381.021343,
     "geom:bbox":"45.407661,33.6863906531,45.9703758441,34.602293",
     "geom:latitude":34.111843,
     "geom:longitude":45.653692,
@@ -115,9 +115,10 @@
         "hasc:id":"IR.BK.QS",
         "wd:id":"Q767866"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120944,
-    "wof:geomhash":"95d52a3c690316f06733a2e2fcf116aa",
+    "wof:geomhash":"885726c52aae4800933d6fda5085b9cc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108720311,
-    "wof:lastmodified":1566718587,
+    "wof:lastmodified":1695886123,
     "wof:name":"Qasr-e-Shirin",
     "wof:parent_id":85672379,
     "wof:placetype":"county",

--- a/data/110/872/031/3/1108720313.geojson
+++ b/data/110/872/031/3/1108720313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.528066,
-    "geom:area_square_m":15730815070.389095,
+    "geom:area_square_m":15730816012.497864,
     "geom:bbox":"58.632251,33.075541,60.947515,34.149353",
     "geom:latitude":33.63815,
     "geom:longitude":59.678696,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.QA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120945,
-    "wof:geomhash":"847d510f97945c8b6f6bf47dd19a1033",
+    "wof:geomhash":"6ffa94431ba06338cddadc66420b6f82",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720313,
-    "wof:lastmodified":1627522225,
+    "wof:lastmodified":1695886701,
     "wof:name":"Qayenat",
     "wof:parent_id":85672391,
     "wof:placetype":"county",

--- a/data/110/872/031/5/1108720315.geojson
+++ b/data/110/872/031/5/1108720315.geojson
@@ -212,6 +212,7 @@
     "wof:concordances":{
         "hasc:id":"IR.QZ.QZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120947,
     "wof:geomhash":"3c456408ec9180c1a77e69077f2bf582",
@@ -224,7 +225,7 @@
         }
     ],
     "wof:id":1108720315,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886124,
     "wof:name":"Qazvin",
     "wof:parent_id":85672367,
     "wof:placetype":"county",

--- a/data/110/872/031/7/1108720317.geojson
+++ b/data/110/872/031/7/1108720317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.155375,
-    "geom:area_square_m":1715217850.579666,
+    "geom:area_square_m":1715217945.59894,
     "geom:bbox":"54.485443,25.889584,56.502888,27.104584",
     "geom:latitude":26.77661,
     "geom:longitude":55.807731,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.HG.QE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120948,
-    "wof:geomhash":"eb5454792e03a9b834b6ee3492e85362",
+    "wof:geomhash":"1e01c5bf218287b9eee5efebdb7c68c6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720317,
-    "wof:lastmodified":1627522226,
+    "wof:lastmodified":1695886701,
     "wof:name":"Qeshm, Abumusa",
     "wof:parent_id":85672337,
     "wof:placetype":"county",

--- a/data/110/872/031/9/1108720319.geojson
+++ b/data/110/872/031/9/1108720319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.3139,
-    "geom:area_square_m":3416183903.108317,
+    "geom:area_square_m":3416184916.717964,
     "geom:bbox":"52.443159,28.041475,53.522429,28.614382",
     "geom:latitude":28.341174,
     "geom:longitude":52.91062,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.QI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120949,
-    "wof:geomhash":"04e005cf7befa5398298d69e14a10ab9",
+    "wof:geomhash":"8a6bf50ef678f3f680355667d52d00ea",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720319,
-    "wof:lastmodified":1627522226,
+    "wof:lastmodified":1695886701,
     "wof:name":"Qirokarzin",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/872/032/1/1108720321.geojson
+++ b/data/110/872/032/1/1108720321.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.131443,
-    "geom:area_square_m":11502498953.350792,
+    "geom:area_square_m":11502498953.350594,
     "geom:bbox":"50.084897,34.152182,51.966353,35.180244",
     "geom:latitude":34.697332,
     "geom:longitude":51.025071,
@@ -154,12 +154,13 @@
         "hasc:id":"IR.QM.QM",
         "wd:id":"Q1264575"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85672351
     ],
     "wof:country":"IR",
     "wof:created":1476120950,
-    "wof:geomhash":"a6568bdfd435e85d9da24d33658c8dcc",
+    "wof:geomhash":"d471d7ca6c3b8e5c4d1ab2a240a57c98",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -169,7 +170,7 @@
         }
     ],
     "wof:id":1108720321,
-    "wof:lastmodified":1690934535,
+    "wof:lastmodified":1695886652,
     "wof:name":"Qom",
     "wof:parent_id":85672351,
     "wof:placetype":"county",

--- a/data/110/872/032/5/1108720325.geojson
+++ b/data/110/872/032/5/1108720325.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.467994,
-    "geom:area_square_m":4724457822.248919,
+    "geom:area_square_m":4724457641.902536,
     "geom:bbox":"47.10963,34.927056,48.191998,35.687671",
     "geom:latitude":35.272171,
     "geom:longitude":47.642456,
@@ -148,9 +148,10 @@
         "hasc:id":"IR.KD.QO",
         "wd:id":"Q1282057"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120951,
-    "wof:geomhash":"971bf1082b6777dc88e64971b18bd16a",
+    "wof:geomhash":"dec8cab53dd50a5c9b1b3ce7701fdf86",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1108720325,
-    "wof:lastmodified":1690934535,
+    "wof:lastmodified":1695886131,
     "wof:name":"Qorveh",
     "wof:parent_id":85672387,
     "wof:placetype":"county",

--- a/data/110/872/032/7/1108720327.geojson
+++ b/data/110/872/032/7/1108720327.geojson
@@ -122,6 +122,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.QU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120952,
     "wof:geomhash":"b33a7f13286858439bc5aa04093a2a58",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108720327,
-    "wof:lastmodified":1694498101,
+    "wof:lastmodified":1695886652,
     "wof:name":"Quchan",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/872/032/9/1108720329.geojson
+++ b/data/110/872/032/9/1108720329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.961114,
-    "geom:area_square_m":10229162649.913385,
+    "geom:area_square_m":10229162720.403128,
     "geom:bbox":"54.944108,29.903399,56.687599,31.230713",
     "geom:latitude":30.600683,
     "geom:longitude":55.774802,
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KE.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120954,
-    "wof:geomhash":"ed2bc325da0237893da3750989f95127",
+    "wof:geomhash":"ce36690614ab42c0caf4651c8ce47e23",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108720329,
-    "wof:lastmodified":1627522226,
+    "wof:lastmodified":1695886701,
     "wof:name":"Rafsanjan",
     "wof:parent_id":85672409,
     "wof:placetype":"county",

--- a/data/110/872/033/1/1108720331.geojson
+++ b/data/110/872/033/1/1108720331.geojson
@@ -101,6 +101,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120955,
     "wof:geomhash":"59bdf54a49e63f3809178181953773d7",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108720331,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886131,
     "wof:name":"Ramhormoz",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/872/033/3/1108720333.geojson
+++ b/data/110/872/033/3/1108720333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07292,
-    "geom:area_square_m":722157758.269197,
+    "geom:area_square_m":722158165.642498,
     "geom:bbox":"50.363325,36.577795,50.772183,36.969702",
     "geom:latitude":36.782758,
     "geom:longitude":50.553979,
@@ -151,9 +151,10 @@
         "hasc:id":"IR.MN.RA",
         "wd:id":"Q968801"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120956,
-    "wof:geomhash":"6ec4a638b5f37566c2b568ab740daab3",
+    "wof:geomhash":"d0584127bf202936dcc896c539d83afb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -163,7 +164,7 @@
         }
     ],
     "wof:id":1108720333,
-    "wof:lastmodified":1690934536,
+    "wof:lastmodified":1695886131,
     "wof:name":"Ramsar",
     "wof:parent_id":85672303,
     "wof:placetype":"county",

--- a/data/110/872/033/5/1108720335.geojson
+++ b/data/110/872/033/5/1108720335.geojson
@@ -92,6 +92,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120957,
     "wof:geomhash":"1fa74e3dadbc997b9a6171210ce065d0",
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108720335,
-    "wof:lastmodified":1694498050,
+    "wof:lastmodified":1695886701,
     "wof:name":"Ramshir",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/872/033/7/1108720337.geojson
+++ b/data/110/872/033/7/1108720337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.082941,
-    "geom:area_square_m":819529981.530709,
+    "geom:area_square_m":819530301.117177,
     "geom:bbox":"54.904308,36.783549,55.273147,37.145591",
     "geom:latitude":36.956903,
     "geom:longitude":55.097411,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GO.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120958,
-    "wof:geomhash":"f4cd0143fead6753be6dc2280fcc6ec8",
+    "wof:geomhash":"1ce2e09c4a32c668666703b7713bfaa2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720337,
-    "wof:lastmodified":1627522226,
+    "wof:lastmodified":1695886701,
     "wof:name":"Ramyan",
     "wof:parent_id":85672299,
     "wof:placetype":"county",

--- a/data/110/872/033/9/1108720339.geojson
+++ b/data/110/872/033/9/1108720339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.123271,
-    "geom:area_square_m":1212923614.63787,
+    "geom:area_square_m":1212923614.637823,
     "geom:bbox":"49.4739936544,37.0283472366,49.9118008086,37.4568885698",
     "geom:latitude":37.274599,
     "geom:longitude":49.681407,
@@ -231,9 +231,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GI.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120959,
-    "wof:geomhash":"0bcb7161205461bf40c4971b58f72790",
+    "wof:geomhash":"2450d22bd29aad395bc56bca9c222199",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -243,7 +244,7 @@
         }
     ],
     "wof:id":1108720339,
-    "wof:lastmodified":1566718603,
+    "wof:lastmodified":1695886131,
     "wof:name":"Rasht",
     "wof:parent_id":85672383,
     "wof:placetype":"county",

--- a/data/110/872/034/3/1108720343.geojson
+++ b/data/110/872/034/3/1108720343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.419235,
-    "geom:area_square_m":4255141565.958917,
+    "geom:area_square_m":4255142193.447822,
     "geom:bbox":"58.947391,34.399275,59.922193,35.209838",
     "geom:latitude":34.831152,
     "geom:longitude":59.393444,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120961,
-    "wof:geomhash":"9f17a183b5f4932e124886c773f2c572",
+    "wof:geomhash":"f7a18172b40709e0bebcca8a5e22b545",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720343,
-    "wof:lastmodified":1627522226,
+    "wof:lastmodified":1695886702,
     "wof:name":"Rashtkhar",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/872/034/5/1108720345.geojson
+++ b/data/110/872/034/5/1108720345.geojson
@@ -92,6 +92,7 @@
     "wof:concordances":{
         "hasc:id":"IR.BK.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120962,
     "wof:geomhash":"4f8e556e7796c56cbfba5f151f32270e",
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108720345,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886131,
     "wof:name":"Ravansar",
     "wof:parent_id":85672379,
     "wof:placetype":"county",

--- a/data/110/872/034/7/1108720347.geojson
+++ b/data/110/872/034/7/1108720347.geojson
@@ -83,6 +83,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KE.RV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120963,
     "wof:geomhash":"023cc8eb3635bd8d87b32807ea3be85e",
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108720347,
-    "wof:lastmodified":1694498050,
+    "wof:lastmodified":1695886702,
     "wof:name":"Ravar",
     "wof:parent_id":85672409,
     "wof:placetype":"county",

--- a/data/110/872/034/9/1108720349.geojson
+++ b/data/110/872/034/9/1108720349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.252474,
-    "geom:area_square_m":2543639295.693728,
+    "geom:area_square_m":2543639469.204443,
     "geom:bbox":"48.550786,35.184629,49.431896,35.733743",
     "geom:latitude":35.43458,
     "geom:longitude":48.971977,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"IR.HD.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120964,
-    "wof:geomhash":"cabb09c937f444c8413b16d1bfe5a326",
+    "wof:geomhash":"3a520d072ea7612fc8327fb006a0fd29",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108720349,
-    "wof:lastmodified":1627522226,
+    "wof:lastmodified":1695886702,
     "wof:name":"Razan",
     "wof:parent_id":85672355,
     "wof:placetype":"county",

--- a/data/110/872/035/1/1108720351.geojson
+++ b/data/110/872/035/1/1108720351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.227012,
-    "geom:area_square_m":2289717924.347691,
+    "geom:area_square_m":2289717924.347852,
     "geom:bbox":"50.8504313552,35.1130787829,51.6904517594,35.6257685788",
     "geom:latitude":35.342745,
     "geom:longitude":51.27153,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"IR.TE.RE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120965,
-    "wof:geomhash":"18ca15d9e68492b63aaf8d11b882de3f",
+    "wof:geomhash":"37e3cb668de3e39251d4084d90e2f0ac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108720351,
-    "wof:lastmodified":1566718602,
+    "wof:lastmodified":1695886131,
     "wof:name":"Rey",
     "wof:parent_id":85672313,
     "wof:placetype":"county",

--- a/data/110/872/035/3/1108720353.geojson
+++ b/data/110/872/035/3/1108720353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077072,
-    "geom:area_square_m":755767149.714133,
+    "geom:area_square_m":755767149.714104,
     "geom:bbox":"48.6954621417,37.3903163,49.2176940104,37.6717693175",
     "geom:latitude":37.529929,
     "geom:longitude":48.955826,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GI.RZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120966,
-    "wof:geomhash":"b8e4d54f2d842de6b8227fb86e496460",
+    "wof:geomhash":"6a83126cebd54d43ddd5cefe4cfe97b2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108720353,
-    "wof:lastmodified":1566718602,
+    "wof:lastmodified":1695886131,
     "wof:name":"Rezvanshahr",
     "wof:parent_id":85672383,
     "wof:placetype":"county",

--- a/data/110/872/035/5/1108720355.geojson
+++ b/data/110/872/035/5/1108720355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032112,
-    "geom:area_square_m":323248504.476555,
+    "geom:area_square_m":323248709.1991,
     "geom:bbox":"50.897629,35.426258,51.216168,35.592805",
     "geom:latitude":35.503843,
     "geom:longitude":51.071098,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.TE.RO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120968,
-    "wof:geomhash":"ad7759e1dca92d2d1ca0f91f72664139",
+    "wof:geomhash":"7e1556da1e029705acb8f656651e7795",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720355,
-    "wof:lastmodified":1627522226,
+    "wof:lastmodified":1695886702,
     "wof:name":"Robatkarim",
     "wof:parent_id":85672313,
     "wof:placetype":"county",

--- a/data/110/872/035/7/1108720357.geojson
+++ b/data/110/872/035/7/1108720357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.28173,
-    "geom:area_square_m":3086937533.100628,
+    "geom:area_square_m":3086938022.037529,
     "geom:bbox":"56.84596,27.097807,57.472885,27.994452",
     "geom:latitude":27.609101,
     "geom:longitude":57.152776,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"IR.HG.RU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120969,
-    "wof:geomhash":"1b2e2401343f394c9de482be9c40dc8f",
+    "wof:geomhash":"ebf25d9f544856350acc40a1b83b1585",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108720357,
-    "wof:lastmodified":1627522226,
+    "wof:lastmodified":1695886702,
     "wof:name":"Rudan",
     "wof:parent_id":85672337,
     "wof:placetype":"county",

--- a/data/110/872/036/1/1108720361.geojson
+++ b/data/110/872/036/1/1108720361.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.259586,
-    "geom:area_square_m":2570294243.860097,
+    "geom:area_square_m":2570294243.860145,
     "geom:bbox":"49.1266721719,36.5608967945,50.1603854183,37.1006186784",
     "geom:latitude":36.797492,
     "geom:longitude":49.625164,
@@ -118,9 +118,10 @@
         "hasc:id":"IR.GI.RB",
         "wd:id":"Q1291695"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120970,
-    "wof:geomhash":"b4304e770ee3245de9cd3425afaae75c",
+    "wof:geomhash":"d7cc086f86c1b2e72d0454f6a9ac86be",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108720361,
-    "wof:lastmodified":1566718586,
+    "wof:lastmodified":1695886123,
     "wof:name":"Rudbar",
     "wof:parent_id":85672383,
     "wof:placetype":"county",

--- a/data/110/872/036/3/1108720363.geojson
+++ b/data/110/872/036/3/1108720363.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KE.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120971,
     "wof:geomhash":"a36300d83ff4a06bdf7204bd88441986",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108720363,
-    "wof:lastmodified":1694498050,
+    "wof:lastmodified":1695886702,
     "wof:name":"Rudbar-e-Jonub",
     "wof:parent_id":85672409,
     "wof:placetype":"county",

--- a/data/110/872/036/5/1108720365.geojson
+++ b/data/110/872/036/5/1108720365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.137636,
-    "geom:area_square_m":1361360679.355997,
+    "geom:area_square_m":1361360728.510021,
     "geom:bbox":"50.085391,36.636409,50.59595,37.182595",
     "geom:latitude":36.878469,
     "geom:longitude":50.319807,
@@ -151,9 +151,10 @@
         "hasc:id":"IR.GI.RS",
         "wd:id":"Q2570961"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120972,
-    "wof:geomhash":"02d92f6128b5035b17610aa1045f1dc7",
+    "wof:geomhash":"bbb313d5fd37236ade4706c722e8bf30",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -163,7 +164,7 @@
         }
     ],
     "wof:id":1108720365,
-    "wof:lastmodified":1690934528,
+    "wof:lastmodified":1695886124,
     "wof:name":"Rudsar",
     "wof:parent_id":85672383,
     "wof:placetype":"county",

--- a/data/110/872/036/7/1108720367.geojson
+++ b/data/110/872/036/7/1108720367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.757645,
-    "geom:area_square_m":17545972594.710411,
+    "geom:area_square_m":17545972594.710705,
     "geom:bbox":"56.5340639008,35.4722485559,58.2872338072,36.8956796012",
     "geom:latitude":36.163635,
     "geom:longitude":57.473509,
@@ -147,9 +147,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120974,
-    "wof:geomhash":"26aef68743d215333927053ef9f469c1",
+    "wof:geomhash":"4dabeb345a299902f25be1c18aae72d3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1108720367,
-    "wof:lastmodified":1566718586,
+    "wof:lastmodified":1695886123,
     "wof:name":"Sabzevar",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/872/036/9/1108720369.geojson
+++ b/data/110/872/036/9/1108720369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.536903,
-    "geom:area_square_m":5632804444.956003,
+    "geom:area_square_m":5632805219.285056,
     "geom:bbox":"53.010877,31.591477,54.435691,32.318857",
     "geom:latitude":31.95578,
     "geom:longitude":53.605702,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.YA.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120975,
-    "wof:geomhash":"28e2758c4e2a82d4e3aff87333b17a09",
+    "wof:geomhash":"88a63a3af4a146ed0a91a9ded3c35891",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720369,
-    "wof:lastmodified":1627522226,
+    "wof:lastmodified":1695886702,
     "wof:name":"Sadugh",
     "wof:parent_id":85672317,
     "wof:placetype":"county",

--- a/data/110/872/037/1/1108720371.geojson
+++ b/data/110/872/037/1/1108720371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.146395,
-    "geom:area_square_m":1490556168.089534,
+    "geom:area_square_m":1490555669.423368,
     "geom:bbox":"47.121483,34.329857,47.846208,34.797064",
     "geom:latitude":34.571328,
     "geom:longitude":47.507194,
@@ -148,9 +148,10 @@
         "hasc:id":"IR.BK.SH",
         "wd:id":"Q1291793"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120976,
-    "wof:geomhash":"7a71e5382b67a95b36adddf64111e22a",
+    "wof:geomhash":"33cfddf5859f8934f23f274ef479722f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1108720371,
-    "wof:lastmodified":1690934529,
+    "wof:lastmodified":1695886125,
     "wof:name":"Sahneh",
     "wof:parent_id":85672379,
     "wof:placetype":"county",

--- a/data/110/872/037/3/1108720373.geojson
+++ b/data/110/872/037/3/1108720373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.163737,
-    "geom:area_square_m":1663006154.885133,
+    "geom:area_square_m":1663006411.064856,
     "geom:bbox":"45.653259,34.590811,46.406979,35.047672",
     "geom:latitude":34.776231,
     "geom:longitude":46.005319,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.BK.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120977,
-    "wof:geomhash":"fa7d2b37a94a7a9299442db441f5c484",
+    "wof:geomhash":"da5bf6399024b02c6d60f3c3805f0b7f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720373,
-    "wof:lastmodified":1627522227,
+    "wof:lastmodified":1695886702,
     "wof:name":"Salas-e-Babajani",
     "wof:parent_id":85672379,
     "wof:placetype":"county",

--- a/data/110/872/037/5/1108720375.geojson
+++ b/data/110/872/037/5/1108720375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.258317,
-    "geom:area_square_m":2512253477.585759,
+    "geom:area_square_m":2512253477.586008,
     "geom:bbox":"44.222746,37.8456624143,45.1028897948,38.3688790077",
     "geom:latitude":38.138413,
     "geom:longitude":44.652837,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"IR.WA.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120978,
-    "wof:geomhash":"fa4bad943a588577de4b4cf6d218ee30",
+    "wof:geomhash":"10c5efaa5e74381eafb942759a7ab7aa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108720375,
-    "wof:lastmodified":1566718589,
+    "wof:lastmodified":1695886125,
     "wof:name":"Salmas",
     "wof:parent_id":85672369,
     "wof:placetype":"county",

--- a/data/110/872/037/9/1108720379.geojson
+++ b/data/110/872/037/9/1108720379.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.301339,
-    "geom:area_square_m":3038940559.194766,
+    "geom:area_square_m":3038939780.906199,
     "geom:bbox":"46.414777,35.049921,47.324734,35.65702",
     "geom:latitude":35.355072,
     "geom:longitude":46.886312,
@@ -201,9 +201,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KD.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120980,
-    "wof:geomhash":"983cc481705a98ad95fc004be4023aad",
+    "wof:geomhash":"d681f45eaebe777d62f4d1346d05ccbe",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -213,7 +214,7 @@
         }
     ],
     "wof:id":1108720379,
-    "wof:lastmodified":1627522227,
+    "wof:lastmodified":1695886702,
     "wof:name":"Sanandaj",
     "wof:parent_id":85672387,
     "wof:placetype":"county",

--- a/data/110/872/038/1/1108720381.geojson
+++ b/data/110/872/038/1/1108720381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.447723,
-    "geom:area_square_m":4469873185.750221,
+    "geom:area_square_m":4469873436.209368,
     "geom:bbox":"45.842552,35.782629,46.906651,36.463057",
     "geom:latitude":36.157757,
     "geom:longitude":46.378608,
@@ -151,9 +151,10 @@
         "hasc:id":"IR.KD.SQ",
         "wd:id":"Q349004"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120981,
-    "wof:geomhash":"c4d5e7b83522ca433296e932deeb62a7",
+    "wof:geomhash":"e15881a693a2aa30519f327857d36b44",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -163,7 +164,7 @@
         }
     ],
     "wof:id":1108720381,
-    "wof:lastmodified":1690934452,
+    "wof:lastmodified":1695886122,
     "wof:name":"Saqqez",
     "wof:parent_id":85672387,
     "wof:placetype":"county",

--- a/data/110/872/038/3/1108720383.geojson
+++ b/data/110/872/038/3/1108720383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087674,
-    "geom:area_square_m":893642923.189246,
+    "geom:area_square_m":893642816.487818,
     "geom:bbox":"45.722933,34.213216,46.144604,34.686324",
     "geom:latitude":34.4805,
     "geom:longitude":45.916096,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.BK.SP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120982,
-    "wof:geomhash":"d73c4f73b455c0c2fbb01559af18865b",
+    "wof:geomhash":"80647fef90616d51e2b98b93136db7a1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720383,
-    "wof:lastmodified":1627522227,
+    "wof:lastmodified":1695886702,
     "wof:name":"Sar-e-pol-e-Zahab",
     "wof:parent_id":85672379,
     "wof:placetype":"county",

--- a/data/110/872/038/5/1108720385.geojson
+++ b/data/110/872/038/5/1108720385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.358729,
-    "geom:area_square_m":3496357682.505603,
+    "geom:area_square_m":3496357299.478197,
     "geom:bbox":"46.995677,37.739368,47.93692,38.255781",
     "geom:latitude":37.980292,
     "geom:longitude":47.467296,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120983,
-    "wof:geomhash":"78f5b70d5695b02d2a3e5190bccc0ea8",
+    "wof:geomhash":"24fe7215aee2d51bd500dce7db371ec5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108720385,
-    "wof:lastmodified":1627522227,
+    "wof:lastmodified":1695886702,
     "wof:name":"Sarab",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/872/038/7/1108720387.geojson
+++ b/data/110/872/038/7/1108720387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.535696,
-    "geom:area_square_m":5338509262.656549,
+    "geom:area_square_m":5338509262.656726,
     "geom:bbox":"60.2106926944,35.8953056335,61.230656,36.644345",
     "geom:latitude":36.298789,
     "geom:longitude":60.785789,
@@ -117,9 +117,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120985,
-    "wof:geomhash":"1e4616496cdea5f701105674071e6f06",
+    "wof:geomhash":"57638cb59eb16434c4fa8059c97eee4e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108720387,
-    "wof:lastmodified":1566718584,
+    "wof:lastmodified":1695886123,
     "wof:name":"Sarakhs",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/872/038/9/1108720389.geojson
+++ b/data/110/872/038/9/1108720389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.394093,
-    "geom:area_square_m":26317934693.109722,
+    "geom:area_square_m":26317934607.621384,
     "geom:bbox":"61.094401,26.484409,63.333201,28.086717",
     "geom:latitude":27.247248,
     "geom:longitude":62.167358,
@@ -139,9 +139,10 @@
         "hasc:id":"IR.SB.SA",
         "wd:id":"Q1279055"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120986,
-    "wof:geomhash":"83b06e2bd1acc34cbda314e40e508cf0",
+    "wof:geomhash":"3374b5384c8bce366c644079a6f07d72",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108720389,
-    "wof:lastmodified":1690934451,
+    "wof:lastmodified":1695886650,
     "wof:name":"Saravan",
     "wof:parent_id":85672405,
     "wof:placetype":"county",

--- a/data/110/872/039/1/1108720391.geojson
+++ b/data/110/872/039/1/1108720391.geojson
@@ -90,7 +90,7 @@
         }
     ],
     "wof:id":1108720391,
-    "wof:lastmodified":1694498051,
+    "wof:lastmodified":1695886702,
     "wof:name":"Sarayan",
     "wof:parent_id":85672391,
     "wof:placetype":"county",

--- a/data/110/872/039/3/1108720393.geojson
+++ b/data/110/872/039/3/1108720393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.983529,
-    "geom:area_square_m":10887125936.249979,
+    "geom:area_square_m":10887125916.637375,
     "geom:bbox":"60.618511,25.804221,62.315223,27.060892",
     "geom:latitude":26.463091,
     "geom:longitude":61.3695,
@@ -133,9 +133,10 @@
         "hasc:id":"IR.SB.SB",
         "wd:id":"Q1278763"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120989,
-    "wof:geomhash":"633f0c6693f60f98c0be6ab671e85281",
+    "wof:geomhash":"bb33396ae6849c76cffdf63462a98f2d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108720393,
-    "wof:lastmodified":1690934530,
+    "wof:lastmodified":1695886126,
     "wof:name":"Sarbaz",
     "wof:parent_id":85672405,
     "wof:placetype":"county",

--- a/data/110/872/039/7/1108720397.geojson
+++ b/data/110/872/039/7/1108720397.geojson
@@ -77,6 +77,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KJ.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120990,
     "wof:geomhash":"bff6a2be27b392c3d6856b75c550d02d",
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108720397,
-    "wof:lastmodified":1694498051,
+    "wof:lastmodified":1695886702,
     "wof:name":"Sarbisheh",
     "wof:parent_id":85672391,
     "wof:placetype":"county",

--- a/data/110/872/039/9/1108720399.geojson
+++ b/data/110/872/039/9/1108720399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.138296,
-    "geom:area_square_m":1379381602.781775,
+    "geom:area_square_m":1379380802.362809,
     "geom:bbox":"45.233421,35.967743,45.700687,36.475507",
     "geom:latitude":36.232216,
     "geom:longitude":45.46067,
@@ -142,9 +142,10 @@
         "hasc:id":"IR.WA.SD",
         "wd:id":"Q1285922"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120991,
-    "wof:geomhash":"f999b331c3835928f4481b64cc5c456f",
+    "wof:geomhash":"5905eff0b18eec8a633e04a7a4a4d679",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108720399,
-    "wof:lastmodified":1690934529,
+    "wof:lastmodified":1695886125,
     "wof:name":"Sardasht",
     "wof:parent_id":85672369,
     "wof:placetype":"county",

--- a/data/110/872/040/1/1108720401.geojson
+++ b/data/110/872/040/1/1108720401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.371788,
-    "geom:area_square_m":3702514463.832484,
+    "geom:area_square_m":3702514463.832601,
     "geom:bbox":"52.9276786373,35.9653960104,53.9532246663,36.8302088618",
     "geom:latitude":36.352674,
     "geom:longitude":53.345485,
@@ -234,9 +234,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MN.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120992,
-    "wof:geomhash":"e37f6de6569832a829b8153820226599",
+    "wof:geomhash":"f5deead948393aac26a59c55adecd512",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -246,7 +247,7 @@
         }
     ],
     "wof:id":1108720401,
-    "wof:lastmodified":1566718582,
+    "wof:lastmodified":1695886121,
     "wof:name":"Sari",
     "wof:parent_id":85672303,
     "wof:placetype":"county",

--- a/data/110/872/040/3/1108720403.geojson
+++ b/data/110/872/040/3/1108720403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102789,
-    "geom:area_square_m":1038194209.48509,
+    "geom:area_square_m":1038195034.48531,
     "geom:bbox":"46.079421,35.034151,46.717496,35.406606",
     "geom:latitude":35.231476,
     "geom:longitude":46.399394,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KD.SV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120994,
-    "wof:geomhash":"2a5f79946317562ee1bfe75c262aa28f",
+    "wof:geomhash":"12a9e11f765bb0d748fa740d0813f12a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108720403,
-    "wof:lastmodified":1627522227,
+    "wof:lastmodified":1695886703,
     "wof:name":"Sarvabad",
     "wof:parent_id":85672387,
     "wof:placetype":"county",

--- a/data/110/872/040/5/1108720405.geojson
+++ b/data/110/872/040/5/1108720405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.211036,
-    "geom:area_square_m":2108316512.283233,
+    "geom:area_square_m":2108316008.844506,
     "geom:bbox":"52.607713,35.83268,53.22955,36.399488",
     "geom:latitude":36.104653,
     "geom:longitude":52.920003,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MN.SD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120995,
-    "wof:geomhash":"1788b86607e917541152697794cbf0ca",
+    "wof:geomhash":"0d2030494cf3cf56e512c8673d8efb75",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720405,
-    "wof:lastmodified":1627522227,
+    "wof:lastmodified":1695886703,
     "wof:name":"Savadkuh",
     "wof:parent_id":85672303,
     "wof:placetype":"county",

--- a/data/110/872/040/7/1108720407.geojson
+++ b/data/110/872/040/7/1108720407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.456464,
-    "geom:area_square_m":4619155689.097083,
+    "geom:area_square_m":4619155800.047907,
     "geom:bbox":"49.260608,34.751966,50.746062,35.41914",
     "geom:latitude":35.076729,
     "geom:longitude":50.025991,
@@ -166,9 +166,10 @@
         "hasc:id":"IR.MK.SH",
         "wd:id":"Q1277821"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120996,
-    "wof:geomhash":"6b2d9e0bd1d950f36e1486836772161c",
+    "wof:geomhash":"3cc5e17fb2c090fddd44959fef4b75fb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":1108720407,
-    "wof:lastmodified":1690934449,
+    "wof:lastmodified":1695886651,
     "wof:name":"Saveh",
     "wof:parent_id":85672347,
     "wof:placetype":"county",

--- a/data/110/872/040/9/1108720409.geojson
+++ b/data/110/872/040/9/1108720409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.289665,
-    "geom:area_square_m":2895923259.265049,
+    "geom:area_square_m":2895923409.835828,
     "geom:bbox":"50.331933,35.750921,51.176268,36.34181",
     "geom:latitude":36.048292,
     "geom:longitude":50.735779,
@@ -154,9 +154,10 @@
         "hasc:id":"IR.AL.SA",
         "wd:id":"Q1274555"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120998,
-    "wof:geomhash":"b5ebc9782faa3e214d7bd82739b8c17f",
+    "wof:geomhash":"38c245f3759f2eb8b9bbb22f3a5d4acc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":1108720409,
-    "wof:lastmodified":1690934449,
+    "wof:lastmodified":1695886121,
     "wof:name":"Savojbolagh",
     "wof:parent_id":85672415,
     "wof:placetype":"county",

--- a/data/110/872/041/1/1108720411.geojson
+++ b/data/110/872/041/1/1108720411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.149374,
-    "geom:area_square_m":1534297894.747487,
+    "geom:area_square_m":1534298095.919179,
     "geom:bbox":"47.72225,33.653325,48.517795,34.013648",
     "geom:latitude":33.831005,
     "geom:longitude":48.169353,
@@ -154,9 +154,10 @@
         "hasc:id":"IR.LO.SE",
         "wd:id":"Q1270900"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476120999,
-    "wof:geomhash":"d90dbfa4238e3790bbe168f197e2b090",
+    "wof:geomhash":"779549e087568a9106d8ac1d0f3d6313",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":1108720411,
-    "wof:lastmodified":1690934447,
+    "wof:lastmodified":1695886119,
     "wof:name":"Selseleh",
     "wof:parent_id":85672329,
     "wof:placetype":"county",

--- a/data/110/872/041/5/1108720415.geojson
+++ b/data/110/872/041/5/1108720415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.497706,
-    "geom:area_square_m":5259598562.399437,
+    "geom:area_square_m":5259598562.39942,
     "geom:bbox":"51.2622545471,30.6987467647,51.9702216329,31.8491967646",
     "geom:latitude":31.279865,
     "geom:longitude":51.600119,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121000,
-    "wof:geomhash":"6ae712840175bbce976b7f89f8104566",
+    "wof:geomhash":"279b2b0cca006ed992a70ea0edcdffd2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108720415,
-    "wof:lastmodified":1566718579,
+    "wof:lastmodified":1695886120,
     "wof:name":"Semirom",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/872/041/7/1108720417.geojson
+++ b/data/110/872/041/7/1108720417.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121001,
     "wof:geomhash":"88300a7db80e45cd30ee8e63d4ae42c9",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108720417,
-    "wof:lastmodified":1694498050,
+    "wof:lastmodified":1695886696,
     "wof:name":"Semirom-e-Sofla",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/872/041/9/1108720419.geojson
+++ b/data/110/872/041/9/1108720419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.188005,
-    "geom:area_square_m":22141960163.84367,
+    "geom:area_square_m":22141959811.530022,
     "geom:bbox":"52.780329,34.245075,54.188551,36.172183",
     "geom:latitude":35.071851,
     "geom:longitude":53.494027,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"IR.SM.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121002,
-    "wof:geomhash":"83be5266f350873b76807a80d91044d8",
+    "wof:geomhash":"580c18f71be745bd4d83ea1fa60c2af0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108720419,
-    "wof:lastmodified":1627522227,
+    "wof:lastmodified":1695886703,
     "wof:name":"Semnan",
     "wof:parent_id":85672309,
     "wof:placetype":"county",

--- a/data/110/872/042/1/1108720421.geojson
+++ b/data/110/872/042/1/1108720421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.264573,
-    "geom:area_square_m":2828342358.125429,
+    "geom:area_square_m":2828341926.55085,
     "geom:bbox":"51.689873,29.817455,52.602242,30.590096",
     "geom:latitude":30.169065,
     "geom:longitude":52.125526,
@@ -151,9 +151,10 @@
         "hasc:id":"IR.FA.SE",
         "wd:id":"Q1020632"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121004,
-    "wof:geomhash":"d59cbb4a1a15a5086e6e0328f0b6563d",
+    "wof:geomhash":"28790d0579d36a9e8b948dc39d3fc386",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -163,7 +164,7 @@
         }
     ],
     "wof:id":1108720421,
-    "wof:lastmodified":1690934530,
+    "wof:lastmodified":1695886126,
     "wof:name":"Sepidan",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/872/042/3/1108720423.geojson
+++ b/data/110/872/042/3/1108720423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.270058,
-    "geom:area_square_m":2622598442.523567,
+    "geom:area_square_m":2622598442.523535,
     "geom:bbox":"45.0874312828,38.0016181448,46.3427321078,38.4827615223",
     "geom:latitude":38.24515,
     "geom:longitude":45.747544,
@@ -111,9 +111,10 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121005,
-    "wof:geomhash":"bf741e3d1dd77b810dd0b2e5fc67949f",
+    "wof:geomhash":"e007a77ba4277744c03c180f920ca5c7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108720423,
-    "wof:lastmodified":1566718592,
+    "wof:lastmodified":1695886126,
     "wof:name":"Shabestar",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/872/042/5/1108720425.geojson
+++ b/data/110/872/042/5/1108720425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.334392,
-    "geom:area_square_m":3557330395.495363,
+    "geom:area_square_m":3557330130.90078,
     "geom:bbox":"48.3232,30.297505,49.052097,30.985083",
     "geom:latitude":30.645296,
     "geom:longitude":48.678263,
@@ -142,9 +142,10 @@
         "hasc:id":"IR.KZ.SD",
         "wd:id":"Q1279136"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121006,
-    "wof:geomhash":"831d4ddd502b4c6713ac7c1a9e90a06b",
+    "wof:geomhash":"5391ed3730f1b32824578f974c52b991",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108720425,
-    "wof:lastmodified":1690934530,
+    "wof:lastmodified":1695886127,
     "wof:name":"Shadegan",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/872/042/7/1108720427.geojson
+++ b/data/110/872/042/7/1108720427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062309,
-    "geom:area_square_m":614618965.592128,
+    "geom:area_square_m":614618965.592083,
     "geom:bbox":"49.098632761,36.9621210174,49.542347299,37.308370769",
     "geom:latitude":37.086921,
     "geom:longitude":49.371384,
@@ -108,9 +108,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GI.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121008,
-    "wof:geomhash":"857047b37dffad7c0eb1cdd1871fe195",
+    "wof:geomhash":"fa232b0b9e88204eaed5cc7ca2162999",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108720427,
-    "wof:lastmodified":1566718592,
+    "wof:lastmodified":1695886127,
     "wof:name":"Shaft",
     "wof:parent_id":85672383,
     "wof:placetype":"county",

--- a/data/110/872/042/9/1108720429.geojson
+++ b/data/110/872/042/9/1108720429.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.228478,
-    "geom:area_square_m":2265814863.069161,
+    "geom:area_square_m":2265814495.595355,
     "geom:bbox":"46.239039,36.395704,46.987922,36.934256",
     "geom:latitude":36.677473,
     "geom:longitude":46.643107,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.WA.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121009,
-    "wof:geomhash":"fff4046b7f24ee2a8d74f10a8506282a",
+    "wof:geomhash":"76791e8c8ae136bc78c699a0c9727e7a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720429,
-    "wof:lastmodified":1627522227,
+    "wof:lastmodified":1695886703,
     "wof:name":"Shahindezh",
     "wof:parent_id":85672369,
     "wof:placetype":"county",

--- a/data/110/872/043/3/1108720433.geojson
+++ b/data/110/872/043/3/1108720433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.267634,
-    "geom:area_square_m":13541566427.473969,
+    "geom:area_square_m":13541565146.58709,
     "geom:bbox":"54.337815,29.449683,55.832543,31.065822",
     "geom:latitude":30.238214,
     "geom:longitude":54.991419,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KE.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121010,
-    "wof:geomhash":"b1734bcd07baad14af2405d3ac07478a",
+    "wof:geomhash":"9c4fadcd29e6cacaf69c82c24f08567a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720433,
-    "wof:lastmodified":1627522228,
+    "wof:lastmodified":1695886703,
     "wof:name":"Shahr-e-Babak",
     "wof:parent_id":85672409,
     "wof:placetype":"county",

--- a/data/110/872/043/5/1108720435.geojson
+++ b/data/110/872/043/5/1108720435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.426326,
-    "geom:area_square_m":4457219053.181252,
+    "geom:area_square_m":4457218794.402362,
     "geom:bbox":"50.353804,31.66953,51.192167,32.719003",
     "geom:latitude":32.271963,
     "geom:longitude":50.773034,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.CM.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121011,
-    "wof:geomhash":"ca7b34738242b6295f41335cbe6c9b65",
+    "wof:geomhash":"f88e7dcfdde9ea07e5b8adb21957bf3f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720435,
-    "wof:lastmodified":1627522228,
+    "wof:lastmodified":1695886703,
     "wof:name":"Shahr-e-Kord",
     "wof:parent_id":85672319,
     "wof:placetype":"county",

--- a/data/110/872/043/7/1108720437.geojson
+++ b/data/110/872/043/7/1108720437.geojson
@@ -110,6 +110,7 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121013,
     "wof:geomhash":"2fe38bf81d75f96529a4b3a74df9476f",
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108720437,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886129,
     "wof:name":"Shahreza",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/872/043/9/1108720439.geojson
+++ b/data/110/872/043/9/1108720439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134045,
-    "geom:area_square_m":1347426817.656313,
+    "geom:area_square_m":1347427029.606385,
     "geom:bbox":"50.33282,35.475954,51.22635,35.741609",
     "geom:latitude":35.61662,
     "geom:longitude":50.80275,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"IR.TE.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121014,
-    "wof:geomhash":"fae00981413e247686229fdcd644c5da",
+    "wof:geomhash":"6611f1ea7623fc1cf656ac88be34ce72",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108720439,
-    "wof:lastmodified":1627522228,
+    "wof:lastmodified":1695886703,
     "wof:name":"Shahriar",
     "wof:parent_id":85672313,
     "wof:placetype":"county",

--- a/data/110/872/044/1/1108720441.geojson
+++ b/data/110/872/044/1/1108720441.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.131913,
-    "geom:area_square_m":51570870671.513809,
+    "geom:area_square_m":51570870870.347061,
     "geom:bbox":"54.570103,34.239397,57.051977,37.337635",
     "geom:latitude":35.633932,
     "geom:longitude":55.682853,
@@ -145,9 +145,10 @@
         "hasc:id":"IR.SM.SH",
         "wd:id":"Q1286402"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121015,
-    "wof:geomhash":"ed8611ee06c465c6fec360fa49e81602",
+    "wof:geomhash":"853c67e618244a3e60356103d71573d4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108720441,
-    "wof:lastmodified":1690934533,
+    "wof:lastmodified":1695886652,
     "wof:name":"Shahrud",
     "wof:parent_id":85672309,
     "wof:placetype":"county",

--- a/data/110/872/044/3/1108720443.geojson
+++ b/data/110/872/044/3/1108720443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.794093,
-    "geom:area_square_m":8130783071.769846,
+    "geom:area_square_m":8130783228.650734,
     "geom:bbox":"48.950463,33.604973,50.308602,34.633958",
     "geom:latitude":34.099821,
     "geom:longitude":49.545251,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MK.SZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121017,
-    "wof:geomhash":"961db0e8ebd63257e53006c30462c033",
+    "wof:geomhash":"f2d0a4f8e530562c9bbf2c2c24c752aa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720443,
-    "wof:lastmodified":1627522228,
+    "wof:lastmodified":1695886703,
     "wof:name":"Shazand, Arak",
     "wof:parent_id":85672347,
     "wof:placetype":"county",

--- a/data/110/872/044/5/1108720445.geojson
+++ b/data/110/872/044/5/1108720445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.121288,
-    "geom:area_square_m":1214609743.117889,
+    "geom:area_square_m":1214609658.972042,
     "geom:bbox":"51.340375,35.765986,51.878781,36.139567",
     "geom:latitude":35.916246,
     "geom:longitude":51.606668,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"IR.TE.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121018,
-    "wof:geomhash":"ec20ba7ca1b2b08aa271212c2bc47229",
+    "wof:geomhash":"6acccb6bc79cb118abed12d775bd5de5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108720445,
-    "wof:lastmodified":1627522228,
+    "wof:lastmodified":1695886703,
     "wof:name":"Shemiranat",
     "wof:parent_id":85672313,
     "wof:placetype":"county",

--- a/data/110/872/044/7/1108720447.geojson
+++ b/data/110/872/044/7/1108720447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.96954,
-    "geom:area_square_m":10435713653.413013,
+    "geom:area_square_m":10435714002.868633,
     "geom:bbox":"51.805436,29.014267,53.589373,29.945105",
     "geom:latitude":29.485623,
     "geom:longitude":52.696843,
@@ -157,9 +157,10 @@
         "hasc:id":"IR.FA.SH",
         "wd:id":"Q2422280"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121019,
-    "wof:geomhash":"4b5391ac45311863a281e7daaff474b9",
+    "wof:geomhash":"4d502f6464378d0147014c2fc632333a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -169,7 +170,7 @@
         }
     ],
     "wof:id":1108720447,
-    "wof:lastmodified":1690934533,
+    "wof:lastmodified":1695886129,
     "wof:name":"Shiraz",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/110/872/045/1/1108720451.geojson
+++ b/data/110/872/045/1/1108720451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.399843,
-    "geom:area_square_m":3920188182.6978,
+    "geom:area_square_m":3920188372.115397,
     "geom:bbox":"57.467082,37.095305,58.287436,37.923115",
     "geom:latitude":37.542545,
     "geom:longitude":57.891516,
@@ -147,9 +147,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KS.SV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121021,
-    "wof:geomhash":"60117c81fc6331719969c717089bc29f",
+    "wof:geomhash":"f6a72c27bfc3e1d8d8fb08210ccb1cc2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1108720451,
-    "wof:lastmodified":1636495415,
+    "wof:lastmodified":1695886651,
     "wof:name":"Shirvan",
     "wof:parent_id":85672401,
     "wof:placetype":"county",

--- a/data/110/872/045/3/1108720453.geojson
+++ b/data/110/872/045/3/1108720453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.211179,
-    "geom:area_square_m":2171896778.696146,
+    "geom:area_square_m":2171896787.128881,
     "geom:bbox":"46.289813,33.382476,47.513597,33.993179",
     "geom:latitude":33.721803,
     "geom:longitude":46.857025,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.IL.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121022,
-    "wof:geomhash":"bea74251482e5805608f459f7d758b75",
+    "wof:geomhash":"dfa8cc958c40f549cc4e07139e9c1067",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720453,
-    "wof:lastmodified":1627522228,
+    "wof:lastmodified":1695886703,
     "wof:name":"Shirvan and Chardavel",
     "wof:parent_id":85672333,
     "wof:placetype":"county",

--- a/data/110/872/045/5/1108720455.geojson
+++ b/data/110/872/045/5/1108720455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.346563,
-    "geom:area_square_m":3632725826.043808,
+    "geom:area_square_m":3632726382.350474,
     "geom:bbox":"47.667335,31.705043,48.661693,32.509584",
     "geom:latitude":32.03565,
     "geom:longitude":48.218923,
@@ -166,9 +166,10 @@
         "hasc:id":"IR.KZ.SS",
         "wd:id":"Q1274936"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121024,
-    "wof:geomhash":"b688ade0643f4e624a95df5a35d09a4d",
+    "wof:geomhash":"a01e13964f2ea964a64d3662b4164312",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":1108720455,
-    "wof:lastmodified":1690934531,
+    "wof:lastmodified":1695886127,
     "wof:name":"Shush",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/872/045/7/1108720457.geojson
+++ b/data/110/872/045/7/1108720457.geojson
@@ -143,6 +143,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KZ.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121025,
     "wof:geomhash":"817100fb0b7545278eb898d11358c609",
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":1108720457,
-    "wof:lastmodified":1694497844,
+    "wof:lastmodified":1695886127,
     "wof:name":"Shushtar",
     "wof:parent_id":85672325,
     "wof:placetype":"county",

--- a/data/110/872/045/9/1108720459.geojson
+++ b/data/110/872/045/9/1108720459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.097057,
-    "geom:area_square_m":959102209.307551,
+    "geom:area_square_m":959102209.307515,
     "geom:bbox":"49.7148643615,36.6921686205,50.1288350378,37.1954445107",
     "geom:latitude":36.949262,
     "geom:longitude":49.899894,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GI.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121027,
-    "wof:geomhash":"faf63566e8b4d2935c0fb7f01b570902",
+    "wof:geomhash":"502e9d68ad181858f24b452f1ec06d53",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108720459,
-    "wof:lastmodified":1566718592,
+    "wof:lastmodified":1695886127,
     "wof:name":"Siahkal",
     "wof:parent_id":85672383,
     "wof:placetype":"county",

--- a/data/110/872/046/1/1108720461.geojson
+++ b/data/110/872/046/1/1108720461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.175009,
-    "geom:area_square_m":12661436563.347502,
+    "geom:area_square_m":12661436402.210808,
     "geom:bbox":"54.949841,28.692596,56.456713,30.010945",
     "geom:latitude":29.371281,
     "geom:longitude":55.716872,
@@ -144,9 +144,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KE.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121028,
-    "wof:geomhash":"e1f1e1db63fe96e54779a9a3f4778978",
+    "wof:geomhash":"dae17b09834da8522be21aac968794f0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":1108720461,
-    "wof:lastmodified":1636495414,
+    "wof:lastmodified":1695886651,
     "wof:name":"Sirjan",
     "wof:parent_id":85672409,
     "wof:placetype":"county",

--- a/data/110/872/046/3/1108720463.geojson
+++ b/data/110/872/046/3/1108720463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.229154,
-    "geom:area_square_m":2324951041.730193,
+    "geom:area_square_m":2324950598.894505,
     "geom:bbox":"47.071935,34.635091,47.926821,35.07306",
     "geom:latitude":34.86361,
     "geom:longitude":47.543912,
@@ -108,9 +108,10 @@
     "wof:concordances":{
         "hasc:id":"IR.BK.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121029,
-    "wof:geomhash":"e0de387307fad8ec7d9f9a0c3696d0f0",
+    "wof:geomhash":"e1ff8f21b4812e7c30974e8d681bb009",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108720463,
-    "wof:lastmodified":1627522228,
+    "wof:lastmodified":1695886704,
     "wof:name":"Sonqor",
     "wof:parent_id":85672379,
     "wof:placetype":"county",

--- a/data/110/872/046/5/1108720465.geojson
+++ b/data/110/872/046/5/1108720465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057358,
-    "geom:area_square_m":563758427.169032,
+    "geom:area_square_m":563758208.531296,
     "geom:bbox":"49.051045,37.254598,49.527934,37.499481",
     "geom:latitude":37.356707,
     "geom:longitude":49.298404,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GI.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121030,
-    "wof:geomhash":"431bb259e345c0dae66ad3096bbe9103",
+    "wof:geomhash":"5ff24f48e54168a748a54708b5091c98",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720465,
-    "wof:lastmodified":1627522228,
+    "wof:lastmodified":1695886704,
     "wof:name":"Sumaehsara",
     "wof:parent_id":85672383,
     "wof:placetype":"county",

--- a/data/110/872/046/9/1108720469.geojson
+++ b/data/110/872/046/9/1108720469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.343582,
-    "geom:area_square_m":55214491336.898659,
+    "geom:area_square_m":55214488247.001045,
     "geom:bbox":"55.3877,31.695135,58.365689,35.097995",
     "geom:latitude":33.308002,
     "geom:longitude":56.823342,
@@ -148,9 +148,10 @@
         "hasc:id":"IR.YA.TB",
         "wd:id":"Q1286560"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121031,
-    "wof:geomhash":"e0d1c2a1cfde70cd7272695c3672e71c",
+    "wof:geomhash":"657e64b0ce71fd819609ae5532cfbc6b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1108720469,
-    "wof:lastmodified":1690934447,
+    "wof:lastmodified":1695886119,
     "wof:name":"Tabas",
     "wof:parent_id":85672391,
     "wof:placetype":"county",

--- a/data/110/872/047/1/1108720471.geojson
+++ b/data/110/872/047/1/1108720471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.231001,
-    "geom:area_square_m":2248816072.645051,
+    "geom:area_square_m":2248816072.64515,
     "geom:bbox":"45.8552044831,37.7231491103,46.6716941164,38.4862643492",
     "geom:latitude":38.066149,
     "geom:longitude":46.289718,
@@ -330,9 +330,10 @@
     "wof:concordances":{
         "hasc:id":"IR.EA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121033,
-    "wof:geomhash":"80eca6611cbf07ddca5f0ab796cf32e2",
+    "wof:geomhash":"c09a6485a8c64ddfcf08711e0a12966c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -342,7 +343,7 @@
         }
     ],
     "wof:id":1108720471,
-    "wof:lastmodified":1566718583,
+    "wof:lastmodified":1695886122,
     "wof:name":"Tabriz",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/872/047/3/1108720473.geojson
+++ b/data/110/872/047/3/1108720473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.272082,
-    "geom:area_square_m":2765282787.092693,
+    "geom:area_square_m":2765282787.092717,
     "geom:bbox":"49.4203397966,34.3742297454,50.1667101158,35.0569683128",
     "geom:latitude":34.720409,
     "geom:longitude":49.778659,
@@ -114,9 +114,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MK.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121034,
-    "wof:geomhash":"b2b7a8d40858639ff53a6fbd16a8ecb4",
+    "wof:geomhash":"660f18fe64fe22cec3cb564c38c470ca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108720473,
-    "wof:lastmodified":1566718583,
+    "wof:lastmodified":1695886122,
     "wof:name":"Tafresh",
     "wof:parent_id":85672347,
     "wof:placetype":"county",

--- a/data/110/872/047/5/1108720475.geojson
+++ b/data/110/872/047/5/1108720475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.554444,
-    "geom:area_square_m":5848356773.271352,
+    "geom:area_square_m":5848356773.271421,
     "geom:bbox":"53.2033275701,31.0025999911,54.2986254554,31.8836619466",
     "geom:latitude":31.454326,
     "geom:longitude":53.813792,
@@ -120,9 +120,10 @@
     "wof:concordances":{
         "hasc:id":"IR.YA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121035,
-    "wof:geomhash":"8d1ac26f0f0958ec192dbe6ad056b196",
+    "wof:geomhash":"639a3ffb5ee540650c487480bf282431",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108720475,
-    "wof:lastmodified":1566718583,
+    "wof:lastmodified":1695886122,
     "wof:name":"Taft",
     "wof:parent_id":85672317,
     "wof:placetype":"county",

--- a/data/110/872/047/7/1108720477.geojson
+++ b/data/110/872/047/7/1108720477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.218024,
-    "geom:area_square_m":2166991248.922883,
+    "geom:area_square_m":2166991736.000601,
     "geom:bbox":"46.810826,36.240396,47.391591,36.83307",
     "geom:latitude":36.504482,
     "geom:longitude":47.124063,
@@ -142,9 +142,10 @@
         "hasc:id":"IR.WA.TA",
         "wd:id":"Q967807"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121036,
-    "wof:geomhash":"bf799360ac54ed223d206aa8951a38cf",
+    "wof:geomhash":"4e320bf9c646ccbf2e0f9416a899905a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108720477,
-    "wof:lastmodified":1690934451,
+    "wof:lastmodified":1695886122,
     "wof:name":"Takab",
     "wof:parent_id":85672369,
     "wof:placetype":"county",

--- a/data/110/872/047/9/1108720479.geojson
+++ b/data/110/872/047/9/1108720479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.259465,
-    "geom:area_square_m":2595103820.796601,
+    "geom:area_square_m":2595103545.50793,
     "geom:bbox":"49.144022,35.670388,49.883756,36.360292",
     "geom:latitude":36.014706,
     "geom:longitude":49.542697,
@@ -142,9 +142,10 @@
         "hasc:id":"IR.QZ.TA",
         "wd:id":"Q1291817"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121038,
-    "wof:geomhash":"d38a08400b1e26ad2ed5f3916f30ac56",
+    "wof:geomhash":"bf39526657d956026a9d07ab6a746207",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108720479,
-    "wof:lastmodified":1690934450,
+    "wof:lastmodified":1695886122,
     "wof:name":"Takestan",
     "wof:parent_id":85672367,
     "wof:placetype":"county",

--- a/data/110/872/048/1/1108720481.geojson
+++ b/data/110/872/048/1/1108720481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.179488,
-    "geom:area_square_m":1944656690.252683,
+    "geom:area_square_m":1944656308.987799,
     "geom:bbox":"51.007152,28.270967,51.62909,29.150848",
     "geom:latitude":28.811647,
     "geom:longitude":51.251316,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"IR.BS.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121039,
-    "wof:geomhash":"26789f705e2d64525e3c0cf128847545",
+    "wof:geomhash":"198fc4b9a70339b403aa63e5f83e989a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108720481,
-    "wof:lastmodified":1627522228,
+    "wof:lastmodified":1695886704,
     "wof:name":"Tangestan",
     "wof:parent_id":85672289,
     "wof:placetype":"county",

--- a/data/110/872/048/3/1108720483.geojson
+++ b/data/110/872/048/3/1108720483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.213987,
-    "geom:area_square_m":2114787755.742833,
+    "geom:area_square_m":2114787198.449818,
     "geom:bbox":"48.481586,36.669281,49.328659,37.185542",
     "geom:latitude":36.942222,
     "geom:longitude":48.888058,
@@ -139,9 +139,10 @@
         "hasc:id":"IR.ZA.TA",
         "wd:id":"Q1271024"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121040,
-    "wof:geomhash":"332730a26c7b7bb293bade24bb75f1c5",
+    "wof:geomhash":"b58015a9dc003dd8d3e9c1d3e4781af9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108720483,
-    "wof:lastmodified":1690934447,
+    "wof:lastmodified":1695886120,
     "wof:name":"Tarom",
     "wof:parent_id":85672361,
     "wof:placetype":"county",

--- a/data/110/872/048/7/1108720487.geojson
+++ b/data/110/872/048/7/1108720487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.216617,
-    "geom:area_square_m":2113999903.090028,
+    "geom:area_square_m":2114000038.979915,
     "geom:bbox":"48.571433,37.509518,49.055677,38.284232",
     "geom:latitude":37.884779,
     "geom:longitude":48.78416,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GI.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121041,
-    "wof:geomhash":"fbbbeb72077a17cd59d4caa9473dd5e7",
+    "wof:geomhash":"8effc521c118070ecf79c359822756ca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720487,
-    "wof:lastmodified":1627522228,
+    "wof:lastmodified":1695886704,
     "wof:name":"Tavalesh",
     "wof:parent_id":85672383,
     "wof:placetype":"county",

--- a/data/110/872/048/9/1108720489.geojson
+++ b/data/110/872/048/9/1108720489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.46646,
-    "geom:area_square_m":4732367005.249071,
+    "geom:area_square_m":4732367005.249668,
     "geom:bbox":"60.001034038,34.4503784189,61.080853,35.3213566582",
     "geom:latitude":34.867709,
     "geom:longitude":60.5496,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.TD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121043,
-    "wof:geomhash":"bf98d8ea6714c34b22505d984e8b5331",
+    "wof:geomhash":"bec42a62d37f8972741ccf141aa71dda",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108720489,
-    "wof:lastmodified":1566718579,
+    "wof:lastmodified":1695886120,
     "wof:name":"Taybad",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/872/049/1/1108720491.geojson
+++ b/data/110/872/049/1/1108720491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.164416,
-    "geom:area_square_m":1650561749.248173,
+    "geom:area_square_m":1650561749.248148,
     "geom:bbox":"51.072299,35.518649,51.889893,35.939648",
     "geom:latitude":35.720735,
     "geom:longitude":51.468741,
@@ -567,12 +567,13 @@
     "wof:concordances":{
         "hasc:id":"IR.TE.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421204533
     ],
     "wof:country":"IR",
     "wof:created":1476121044,
-    "wof:geomhash":"0cf91b5beaddcf5626b3a80c86974351",
+    "wof:geomhash":"e25c1a8eeeebb49d8264afc7dd27abe3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -582,7 +583,7 @@
         }
     ],
     "wof:id":1108720491,
-    "wof:lastmodified":1608006801,
+    "wof:lastmodified":1695886415,
     "wof:name":"Tehran",
     "wof:parent_id":85672313,
     "wof:placetype":"county",

--- a/data/110/872/049/3/1108720493.geojson
+++ b/data/110/872/049/3/1108720493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.162708,
-    "geom:area_square_m":1691368428.31917,
+    "geom:area_square_m":1691368928.812011,
     "geom:bbox":"50.54817,32.511421,51.240242,33.058842",
     "geom:latitude":32.788226,
     "geom:longitude":50.956258,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.ES.TK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121045,
-    "wof:geomhash":"56d9ee16d2618a1444e765309c7078f5",
+    "wof:geomhash":"f03ffe72398a13f727904673779be783",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720493,
-    "wof:lastmodified":1627522228,
+    "wof:lastmodified":1695886704,
     "wof:name":"Tiran and Karvan",
     "wof:parent_id":85672291,
     "wof:placetype":"county",

--- a/data/110/872/049/5/1108720495.geojson
+++ b/data/110/872/049/5/1108720495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.215818,
-    "geom:area_square_m":2142052310.831985,
+    "geom:area_square_m":2142051486.594355,
     "geom:bbox":"50.510903,36.271909,51.295922,36.88049",
     "geom:latitude":36.613199,
     "geom:longitude":50.880807,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MN.TO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121046,
-    "wof:geomhash":"f0e2cebf13b63d367b1f788e355f48e0",
+    "wof:geomhash":"01a91fefa7ea4b6505bbaa194d936108",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720495,
-    "wof:lastmodified":1627522229,
+    "wof:lastmodified":1695886704,
     "wof:name":"Tonkabon",
     "wof:parent_id":85672303,
     "wof:placetype":"county",

--- a/data/110/872/049/7/1108720497.geojson
+++ b/data/110/872/049/7/1108720497.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121048,
     "wof:geomhash":"c9da5d4a9202c7786942f99248eee4e7",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108720497,
-    "wof:lastmodified":1694498051,
+    "wof:lastmodified":1695886704,
     "wof:name":"Torbat-e-Heydariyeh",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/872/049/9/1108720499.geojson
+++ b/data/110/872/049/9/1108720499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.810893,
-    "geom:area_square_m":8165206974.086962,
+    "geom:area_square_m":8165207219.011869,
     "geom:bbox":"60.007409,34.903444,61.283935,36.001312",
     "geom:latitude":35.477655,
     "geom:longitude":60.748201,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KV.TJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121049,
-    "wof:geomhash":"63b564e58d7fb1cadb6789af10f368b4",
+    "wof:geomhash":"29abf7aa06023983b859d7bb5ff6abac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720499,
-    "wof:lastmodified":1627522229,
+    "wof:lastmodified":1695886704,
     "wof:name":"Torbat-e-Jam",
     "wof:parent_id":85672397,
     "wof:placetype":"county",

--- a/data/110/872/050/1/1108720501.geojson
+++ b/data/110/872/050/1/1108720501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.161961,
-    "geom:area_square_m":1597199093.386524,
+    "geom:area_square_m":1597198842.72636,
     "geom:bbox":"53.899437,36.818889,54.41424,37.34927",
     "geom:latitude":37.104748,
     "geom:longitude":54.144778,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"IR.GO.TO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121050,
-    "wof:geomhash":"8a8a3ef56fb6747f67f8ecec16d72474",
+    "wof:geomhash":"b956f80981ae8789e6232a6b02db9f3a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108720501,
-    "wof:lastmodified":1627522229,
+    "wof:lastmodified":1695886704,
     "wof:name":"Torkaman",
     "wof:parent_id":85672299,
     "wof:placetype":"county",

--- a/data/110/872/050/5/1108720505.geojson
+++ b/data/110/872/050/5/1108720505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.142704,
-    "geom:area_square_m":1453446295.275723,
+    "geom:area_square_m":1453446671.137357,
     "geom:bbox":"48.070344,34.336457,48.58405,34.767523",
     "geom:latitude":34.544521,
     "geom:longitude":48.331371,
@@ -114,9 +114,10 @@
     "wof:concordances":{
         "hasc:id":"IR.HD.TU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121051,
-    "wof:geomhash":"b3114e677c16ab850e4360be3e4a7632",
+    "wof:geomhash":"74af8ba7afd384fce8468af4b35c8b16",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108720505,
-    "wof:lastmodified":1627522229,
+    "wof:lastmodified":1695886705,
     "wof:name":"Tuyserkan",
     "wof:parent_id":85672355,
     "wof:placetype":"county",

--- a/data/110/872/050/7/1108720507.geojson
+++ b/data/110/872/050/7/1108720507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.185438,
-    "geom:area_square_m":1874548027.241297,
+    "geom:area_square_m":1874548280.199669,
     "geom:bbox":"51.460169,34.864583,52.044252,35.459827",
     "geom:latitude":35.162873,
     "geom:longitude":51.747463,
@@ -162,9 +162,10 @@
     "wof:concordances":{
         "hasc:id":"IR.TE.VA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121052,
-    "wof:geomhash":"e08c47801775cf625fe2604dbbb91dbe",
+    "wof:geomhash":"ab04b3e9bdd886bd51d74f317e866f97",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":1108720507,
-    "wof:lastmodified":1636495417,
+    "wof:lastmodified":1695886652,
     "wof:name":"Varamin",
     "wof:parent_id":85672313,
     "wof:placetype":"county",

--- a/data/110/872/050/9/1108720509.geojson
+++ b/data/110/872/050/9/1108720509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.242121,
-    "geom:area_square_m":2339730247.131485,
+    "geom:area_square_m":2339730037.755815,
     "geom:bbox":"46.029907,38.374063,46.861338,38.794898",
     "geom:latitude":38.601198,
     "geom:longitude":46.452014,
@@ -139,9 +139,10 @@
         "hasc:id":"IR.EA.VA",
         "wd:id":"Q946847"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121054,
-    "wof:geomhash":"3f800c1075d02b03b290790566f7f0be",
+    "wof:geomhash":"0e3f86b80fb117f2a02ca87c98a83558",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108720509,
-    "wof:lastmodified":1690934536,
+    "wof:lastmodified":1695886131,
     "wof:name":"Varzaqan",
     "wof:parent_id":85672373,
     "wof:placetype":"county",

--- a/data/110/872/051/1/1108720511.geojson
+++ b/data/110/872/051/1/1108720511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.238275,
-    "geom:area_square_m":2500405237.707199,
+    "geom:area_square_m":2500405237.70716,
     "geom:bbox":"54.1461747229,31.6584201698,54.8470558202,32.2216645803",
     "geom:latitude":31.934052,
     "geom:longitude":54.516391,
@@ -225,9 +225,10 @@
     "wof:concordances":{
         "hasc:id":"IR.YA.YA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121055,
-    "wof:geomhash":"54483b702c3cbd817b5b683035eb584a",
+    "wof:geomhash":"6beb7992e2b5994efa19f023c625680f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -237,7 +238,7 @@
         }
     ],
     "wof:id":1108720511,
-    "wof:lastmodified":1566718605,
+    "wof:lastmodified":1695886132,
     "wof:name":"Yazd",
     "wof:parent_id":85672317,
     "wof:placetype":"county",

--- a/data/110/872/051/3/1108720513.geojson
+++ b/data/110/872/051/3/1108720513.geojson
@@ -137,6 +137,7 @@
     "wof:concordances":{
         "hasc:id":"IR.SB.ZB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121056,
     "wof:geomhash":"0d2c02375724e7abd25db0481357389b",
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1108720513,
-    "wof:lastmodified":1694498101,
+    "wof:lastmodified":1695886652,
     "wof:name":"Zabol",
     "wof:parent_id":85672405,
     "wof:placetype":"county",

--- a/data/110/872/051/5/1108720515.geojson
+++ b/data/110/872/051/5/1108720515.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"IR.SB.ZB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121058,
     "wof:geomhash":"7a05b2c88430625d8b88a953cb8eddea",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108720515,
-    "wof:lastmodified":1694498051,
+    "wof:lastmodified":1695886705,
     "wof:name":"Zahak",
     "wof:parent_id":85672405,
     "wof:placetype":"county",

--- a/data/110/872/051/7/1108720517.geojson
+++ b/data/110/872/051/7/1108720517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.308933,
-    "geom:area_square_m":35601001019.97805,
+    "geom:area_square_m":35601002453.685081,
     "geom:bbox":"59.425554,28.53621,61.953446,30.766631",
     "geom:latitude":29.52371,
     "geom:longitude":60.350076,
@@ -142,9 +142,10 @@
         "hasc:id":"IR.SB.ZD",
         "wd:id":"Q1278993"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121059,
-    "wof:geomhash":"70af65292742b5839d1864cf1efda9ee",
+    "wof:geomhash":"3546a93319e0aa31bff0e891ee2f9e59",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108720517,
-    "wof:lastmodified":1690934538,
+    "wof:lastmodified":1695886132,
     "wof:name":"Zahedan",
     "wof:parent_id":85672405,
     "wof:placetype":"county",

--- a/data/110/872/051/9/1108720519.geojson
+++ b/data/110/872/051/9/1108720519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.654718,
-    "geom:area_square_m":6478557012.319297,
+    "geom:area_square_m":6478556960.579579,
     "geom:bbox":"47.430265,36.452664,48.914171,37.251618",
     "geom:latitude":36.846041,
     "geom:longitude":48.217634,
@@ -142,9 +142,10 @@
         "hasc:id":"IR.ZA.ZA",
         "wd:id":"Q1282142"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121060,
-    "wof:geomhash":"bcfb3a80bda161b46a27a1f6bdf150ac",
+    "wof:geomhash":"52c03a24227325cdf8de30fccad2f5b1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108720519,
-    "wof:lastmodified":1690934537,
+    "wof:lastmodified":1695886132,
     "wof:name":"Zanjan",
     "wof:parent_id":85672361,
     "wof:placetype":"county",

--- a/data/110/872/052/3/1108720523.geojson
+++ b/data/110/872/052/3/1108720523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.429595,
-    "geom:area_square_m":4558250848.581604,
+    "geom:area_square_m":4558251095.622006,
     "geom:bbox":"55.582284,30.548445,56.961606,31.282385",
     "geom:latitude":30.895798,
     "geom:longitude":56.324335,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"IR.KE.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121061,
-    "wof:geomhash":"0f2512196deb9ed4cdf11978d6cadaa3",
+    "wof:geomhash":"40eb4b72038ab6458d086d9ab8da6af6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108720523,
-    "wof:lastmodified":1627522229,
+    "wof:lastmodified":1695886705,
     "wof:name":"Zarand",
     "wof:parent_id":85672409,
     "wof:placetype":"county",

--- a/data/110/872/052/5/1108720525.geojson
+++ b/data/110/872/052/5/1108720525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.412896,
-    "geom:area_square_m":4163505874.627576,
+    "geom:area_square_m":4163505380.838696,
     "geom:bbox":"49.548383,35.091342,50.96612,35.570584",
     "geom:latitude":35.364199,
     "geom:longitude":50.331635,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.MK.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121062,
-    "wof:geomhash":"1a8bd4ffea906ed0c51496d2be2ae251",
+    "wof:geomhash":"1e87878a43b48d1eeaef2dcd39459053",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720525,
-    "wof:lastmodified":1627522229,
+    "wof:lastmodified":1695886705,
     "wof:name":"Zarandiyeh",
     "wof:parent_id":85672347,
     "wof:placetype":"county",

--- a/data/110/872/052/7/1108720527.geojson
+++ b/data/110/872/052/7/1108720527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.419424,
-    "geom:area_square_m":4566827437.124092,
+    "geom:area_square_m":4566827402.121627,
     "geom:bbox":"54.009066,27.954904,54.907067,28.645859",
     "geom:latitude":28.289237,
     "geom:longitude":54.476237,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"IR.FA.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IR",
     "wof:created":1476121064,
-    "wof:geomhash":"92dbcd346175b7db74d8d44093e1733d",
+    "wof:geomhash":"779688f676cfaed5e731e4ba68b19eb1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108720527,
-    "wof:lastmodified":1627522229,
+    "wof:lastmodified":1695886705,
     "wof:name":"Zarrindasht",
     "wof:parent_id":85672295,
     "wof:placetype":"county",

--- a/data/856/323/61/85632361.geojson
+++ b/data/856/323/61/85632361.geojson
@@ -1316,6 +1316,7 @@
         "hasc:id":"IR",
         "icao:code":"EP",
         "ioc:id":"IRI",
+        "iso:code":"IR",
         "itu:id":"IRN",
         "loc:id":"n79039880",
         "m49:code":"364",
@@ -1330,6 +1331,7 @@
         "wk:page":"Iran",
         "wmo:id":"IR"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:country_alpha3":"IRN",
     "wof:geom_alt":[
@@ -1353,7 +1355,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1694639591,
+    "wof:lastmodified":1695881252,
     "wof:name":"Iran",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/722/83/85672283.geojson
+++ b/data/856/722/83/85672283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.463154,
-    "geom:area_square_m":15544913990.895727,
+    "geom:area_square_m":15544914694.240355,
     "geom:bbox":"49.888523,29.925929,51.888918,31.483588",
     "geom:latitude":30.770688,
     "geom:longitude":50.835065,
@@ -399,16 +399,18 @@
         "gn:id":126878,
         "gp:id":2345771,
         "hasc:id":"IR.KB",
+        "iso:code":"IR-18",
         "iso:id":"IR-18",
         "qs_pg:id":890080,
         "wd:id":"Q180068",
         "wk:page":"Kohgiluyeh and Boyer-Ahmad Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c809195bd7a0addae25512cb24e9bd5e",
+    "wof:geomhash":"f17dbb415f7a3fba6b93ecca6c513db6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -423,7 +425,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934415,
+    "wof:lastmodified":1695884334,
     "wof:name":"Kohgiluyeh and Buyer Ahmad",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/722/89/85672289.geojson
+++ b/data/856/722/89/85672289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.106282,
-    "geom:area_square_m":22815220115.354626,
+    "geom:area_square_m":22815220058.608971,
     "geom:bbox":"50.107082,27.272055,52.940308,30.292324",
     "geom:latitude":28.828214,
     "geom:longitude":51.389827,
@@ -434,17 +434,19 @@
         "gn:id":139816,
         "gp:id":2345781,
         "hasc:id":"IR.BS",
+        "iso:code":"IR-06",
         "iso:id":"IR-06",
         "qs_pg:id":219564,
         "unlc:id":"IR-06",
         "wd:id":"Q132945",
         "wk:page":"Bushehr Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2eddbfdd322355fdbcfa5a4dbac90847",
+    "wof:geomhash":"4ccc317ab9505d76ce9894719efb8232",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -459,7 +461,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934414,
+    "wof:lastmodified":1695884792,
     "wof:name":"Bushehr",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/722/91/85672291.geojson
+++ b/data/856/722/91/85672291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":10.355169,
-    "geom:area_square_m":107221948413.827393,
+    "geom:area_square_m":107221949548.427277,
     "geom:bbox":"49.639404,30.698747,55.497702,34.510005",
     "geom:latitude":33.126259,
     "geom:longitude":52.500612,
@@ -436,17 +436,19 @@
         "gn:id":418862,
         "gp:id":2345787,
         "hasc:id":"IR.ES",
+        "iso:code":"IR-04",
         "iso:id":"IR-04",
         "qs_pg:id":318518,
         "unlc:id":"IR-04",
         "wd:id":"Q1367759",
         "wk:page":"Isfahan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2ef43252ba01e4451a17f124f00f43a1",
+    "wof:geomhash":"a1634895a1e3172ef78a295edb91895f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -461,7 +463,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934414,
+    "wof:lastmodified":1695884334,
     "wof:name":"Esfahan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/722/95/85672295.geojson
+++ b/data/856/722/95/85672295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":11.366927,
-    "geom:area_square_m":122712946443.997879,
+    "geom:area_square_m":122712946519.516846,
     "geom:bbox":"50.606156,27.045973,55.580364,31.670307",
     "geom:latitude":29.165578,
     "geom:longitude":53.259991,
@@ -436,17 +436,19 @@
         "gn:id":134766,
         "gp:id":2345772,
         "hasc:id":"IR.FA",
+        "iso:code":"IR-14",
         "iso:id":"IR-14",
         "qs_pg:id":1168666,
         "unlc:id":"IR-14",
         "wd:id":"Q1004666",
         "wk:page":"Fars Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d3d4d48cc66c2353b6a1464925cd310d",
+    "wof:geomhash":"512cc0bc79156f06542ec2aacd9f03ba",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -461,7 +463,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934413,
+    "wof:lastmodified":1695884334,
     "wof:name":"Fars",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/722/99/85672299.geojson
+++ b/data/856/722/99/85672299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.071233,
-    "geom:area_square_m":20368604642.682545,
+    "geom:area_square_m":20368605605.96109,
     "geom:bbox":"53.860808,36.492382,56.31376,38.127798",
     "geom:latitude":37.314445,
     "geom:longitude":55.07926,
@@ -389,17 +389,19 @@
         "gn:id":443792,
         "gp:id":20070201,
         "hasc:id":"IR.GO",
+        "iso:code":"IR-27",
         "iso:id":"IR-27",
         "qs_pg:id":896390,
         "unlc:id":"IR-27",
         "wd:id":"Q170041",
         "wk:page":"Golestan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d8c9591b737f8cf323823f08e261d25c",
+    "wof:geomhash":"3140e91c5ae78d9a7b7380e81608756d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -414,7 +416,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934415,
+    "wof:lastmodified":1695884334,
     "wof:name":"Golestan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/03/85672303.geojson
+++ b/data/856/723/03/85672303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.411259,
-    "geom:area_square_m":24003157113.538834,
+    "geom:area_square_m":24003157324.614063,
     "geom:bbox":"50.363325,35.757821,54.130535,36.969702",
     "geom:latitude":36.384055,
     "geom:longitude":52.389365,
@@ -424,17 +424,19 @@
         "gn:id":124544,
         "gp:id":2345780,
         "hasc:id":"IR.MN",
+        "iso:code":"IR-21",
         "iso:id":"IR-21",
         "qs_pg:id":423773,
         "unlc:id":"IR-21",
         "wd:id":"Q308864",
         "wk:page":"Mazandaran Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cc88b0fbbd2495ebcc334403b5e4071e",
+    "wof:geomhash":"e1fb3e369f3c2d27a96d7c1cbb8e014a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -449,7 +451,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934421,
+    "wof:lastmodified":1695884335,
     "wof:name":"Mazandaran",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/09/85672309.geojson
+++ b/data/856/723/09/85672309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.651417,
-    "geom:area_square_m":97239023574.515213,
+    "geom:area_square_m":97239022471.433044,
     "geom:bbox":"51.833966,34.239397,57.051977,37.337635",
     "geom:latitude":35.426906,
     "geom:longitude":54.673164,
@@ -396,17 +396,19 @@
         "gn:id":116401,
         "gp:id":2345784,
         "hasc:id":"IR.SM",
+        "iso:code":"IR-12",
         "iso:id":"IR-12",
         "qs_pg:id":1083841,
         "unlc:id":"IR-12",
         "wd:id":"Q168949",
         "wk:page":"Semnan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"72652a369f3ebc27ae943f0673bfb9ca",
+    "wof:geomhash":"30ff7bebd3452e178cf9b75cbb1fcd28",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -421,7 +423,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934426,
+    "wof:lastmodified":1695884793,
     "wof:name":"Semnan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/13/85672313.geojson
+++ b/data/856/723/13/85672313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.363016,
-    "geom:area_square_m":13711598562.546135,
+    "geom:area_square_m":13711598702.952085,
     "geom:bbox":"50.33282,34.864583,53.156625,36.139567",
     "geom:latitude":35.554679,
     "geom:longitude":51.723961,
@@ -441,17 +441,19 @@
         "gn:id":110791,
         "gp:id":2345785,
         "hasc:id":"IR.TE",
+        "iso:code":"IR-07",
         "iso:id":"IR-07",
         "qs_pg:id":318510,
         "unlc:id":"IR-07",
         "wd:id":"Q590866",
         "wk:page":"Tehran Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"df26cde34b10dbd92bc4fa2bef2bde89",
+    "wof:geomhash":"3a78387e25ca70050a0251bed7affce1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -466,7 +468,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934430,
+    "wof:lastmodified":1695884338,
     "wof:name":"Tehran",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/17/85672317.geojson
+++ b/data/856/723/17/85672317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.025294,
-    "geom:area_square_m":73818013672.336365,
+    "geom:area_square_m":73818013598.887909,
     "geom:bbox":"52.808204,29.597132,56.653612,33.365181",
     "geom:latitude":31.806281,
     "geom:longitude":54.60917,
@@ -382,17 +382,19 @@
         "gn:id":111821,
         "gp:id":2345790,
         "hasc:id":"IR.YA",
+        "iso:code":"IR-25",
         "iso:id":"IR-25",
         "qs_pg:id":211640,
         "unlc:id":"IR-25",
         "wd:id":"Q170568",
         "wk:page":"Yazd Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"527bd998fc5db1675d1b1371204236d0",
+    "wof:geomhash":"78d45c051bf189acb2734ab5563a452c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -407,7 +409,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934425,
+    "wof:lastmodified":1695884336,
     "wof:name":"Yazd",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/19/85672319.geojson
+++ b/data/856/723/19/85672319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.564022,
-    "geom:area_square_m":16392965391.510157,
+    "geom:area_square_m":16392965991.004091,
     "geom:bbox":"49.501521,31.150536,51.433034,32.807761",
     "geom:latitude":32.041395,
     "geom:longitude":50.642576,
@@ -412,17 +412,19 @@
         "gn:id":139677,
         "gp:id":2345769,
         "hasc:id":"IR.CM",
+        "iso:code":"IR-08",
         "iso:id":"IR-08",
         "qs_pg:id":890078,
         "unlc:id":"IR-08",
         "wd:id":"Q171702",
         "wk:page":"Chaharmahal and Bakhtiari Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a2f72c1fb92d487db0e75ebd9e75bb9b",
+    "wof:geomhash":"fb12882a61b033458cd34293327d606a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -437,7 +439,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934425,
+    "wof:lastmodified":1695884336,
     "wof:name":"Chahar Mahall and Bakhtiari",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/25/85672325.geojson
+++ b/data/856/723/25/85672325.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.996015,
-    "geom:area_square_m":63241943250.293312,
+    "geom:area_square_m":63241942036.514763,
     "geom:bbox":"47.667335,29.945444,50.550828,32.997462",
     "geom:latitude":31.453852,
     "geom:longitude":49.017523,
@@ -417,17 +417,19 @@
         "gn:id":127082,
         "gp:id":2345778,
         "hasc:id":"IR.KZ",
+        "iso:code":"IR-10",
         "iso:id":"IR-10",
         "qs_pg:id":423771,
         "unlc:id":"IR-10",
         "wd:id":"Q241119",
         "wk:page":"Khuzestan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fb357c9caed96d7840e84eb6121acaab",
+    "wof:geomhash":"4b72344bde6adaf91a114e6e5bab9f36",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -442,7 +444,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934430,
+    "wof:lastmodified":1695884338,
     "wof:name":"Khuzestan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/29/85672329.geojson
+++ b/data/856/723/29/85672329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.74001,
-    "geom:area_square_m":28263873873.675713,
+    "geom:area_square_m":28263874471.410286,
     "geom:bbox":"46.839932,32.654549,50.019319,34.378082",
     "geom:latitude":33.464156,
     "geom:longitude":48.435615,
@@ -410,17 +410,19 @@
         "gn:id":125605,
         "gp:id":2345782,
         "hasc:id":"IR.LO",
+        "iso:code":"IR-20",
         "iso:id":"IR-20",
         "qs_pg:id":229377,
         "unlc:id":"IR-20",
         "wd:id":"Q1131727",
         "wk:page":"Lorestan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f95322340f9d1581c4fbf3aa35e7da31",
+    "wof:geomhash":"2da5ebf221a07b70a526bd20a40cd481",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -435,7 +437,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934423,
+    "wof:lastmodified":1695884336,
     "wof:name":"Lorestan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/33/85672333.geojson
+++ b/data/856/723/33/85672333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.892241,
-    "geom:area_square_m":19596556660.048611,
+    "geom:area_square_m":19596554353.839153,
     "geom:bbox":"45.69466,32.045085,48.045352,34.037425",
     "geom:latitude":33.116458,
     "geom:longitude":46.938353,
@@ -393,17 +393,19 @@
         "gn:id":130801,
         "gp:id":2345775,
         "hasc:id":"IR.IL",
+        "iso:code":"IR-05",
         "iso:id":"IR-05",
         "qs_pg:id":894898,
         "unlc:id":"IR-05",
         "wd:id":"Q170570",
         "wk:page":"Ilam Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"038d489e8623dfaf352f9d119b29545e",
+    "wof:geomhash":"753ebc676e2651e4765a6098b6a6dd99",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -418,7 +420,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934423,
+    "wof:lastmodified":1695884793,
     "wof:name":"Ilam",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/37/85672337.geojson
+++ b/data/856/723/37/85672337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.391021,
-    "geom:area_square_m":70394796891.621338,
+    "geom:area_square_m":70394798138.029694,
     "geom:bbox":"52.743547,25.402889,59.245445,28.883155",
     "geom:latitude":27.019281,
     "geom:longitude":56.476815,
@@ -387,17 +387,19 @@
         "gn:id":131222,
         "gp:id":2345776,
         "hasc:id":"IR.HG",
+        "iso:code":"IR-23",
         "iso:id":"IR-23",
         "qs_pg:id":894893,
         "unlc:id":"IR-23",
         "wd:id":"Q633659",
         "wk:page":"Hormozgan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"76d1b88d40851cba4ef1e9b8ba31ba25",
+    "wof:geomhash":"51e9d1ee2608ab3d4f6ea84b27b301f7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -412,7 +414,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934427,
+    "wof:lastmodified":1695884793,
     "wof:name":"Hormozgan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/43/85672343.geojson
+++ b/data/856/723/43/85672343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.84287,
-    "geom:area_square_m":17846781939.882,
+    "geom:area_square_m":17846783223.492847,
     "geom:bbox":"47.286104,37.105482,48.921819,39.708781",
     "geom:latitude":38.44199,
     "geom:longitude":48.079426,
@@ -410,17 +410,19 @@
         "gn:id":413931,
         "gp:id":20070198,
         "hasc:id":"IR.AR",
+        "iso:code":"IR-03",
         "iso:id":"IR-03",
         "qs_pg:id":219912,
         "unlc:id":"IR-03",
         "wd:id":"Q134228",
         "wk:page":"Ardabil Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"23f2eeddaa70f55e09228573f0af3c84",
+    "wof:geomhash":"fad2651c0019b9b46032713dd6fb40e9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -435,7 +437,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934425,
+    "wof:lastmodified":1695884336,
     "wof:name":"Ardebil",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/47/85672347.geojson
+++ b/data/856/723/47/85672347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.85321,
-    "geom:area_square_m":29077129264.716419,
+    "geom:area_square_m":29077129181.403122,
     "geom:bbox":"48.950463,33.385009,51.050392,35.570584",
     "geom:latitude":34.491297,
     "geom:longitude":49.958319,
@@ -395,17 +395,19 @@
         "gn:id":124763,
         "gp:id":2345783,
         "hasc:id":"IR.MK",
+        "iso:code":"IR-22",
         "iso:id":"IR-22",
         "qs_pg:id":1083840,
         "unlc:id":"IR-22",
         "wd:id":"Q134417",
         "wk:page":"Markazi Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b6abe86b8de449986000a5be6767e735",
+    "wof:geomhash":"5c07e6a0298e164517885948ed26950c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -420,7 +422,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934429,
+    "wof:lastmodified":1695884338,
     "wof:name":"Markazi",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/51/85672351.geojson
+++ b/data/856/723/51/85672351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.131443,
-    "geom:area_square_m":11502498953.350584,
+    "geom:area_square_m":11502498953.350531,
     "geom:bbox":"50.084897,34.152182,51.966353,35.180244",
     "geom:latitude":34.697332,
     "geom:longitude":51.025071,
@@ -396,12 +396,14 @@
         "gn:id":443794,
         "gp:id":20070199,
         "hasc:id":"IR.QM",
+        "iso:code":"IR-26",
         "iso:id":"IR-26",
         "qs_pg:id":241207,
         "unlc:id":"IR-26",
         "wd:id":"Q131664",
         "wk:page":"Qom Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1108720321
     ],
@@ -409,7 +411,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bdf6691767930326498590f27decb3bf",
+    "wof:geomhash":"36c102e27bf6d890c3a03212ea68927f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -424,7 +426,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934422,
+    "wof:lastmodified":1695884793,
     "wof:name":"Qom",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/55/85672355.geojson
+++ b/data/856/723/55/85672355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.909182,
-    "geom:area_square_m":19364282573.705227,
+    "geom:area_square_m":19364282871.063431,
     "geom:bbox":"47.801236,34.001241,49.467432,35.733743",
     "geom:latitude":34.886295,
     "geom:longitude":48.610058,
@@ -404,17 +404,19 @@
         "gn:id":132142,
         "gp:id":2345774,
         "hasc:id":"IR.HD",
+        "iso:code":"IR-24",
         "iso:id":"IR-24",
         "qs_pg:id":191365,
         "unlc:id":"IR-24",
         "wd:id":"Q187373",
         "wk:page":"Hamadan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"58160333f4e1019a53dc7de870084fbf",
+    "wof:geomhash":"f358836beb6f24e0cf7c25d42ec10c93",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -429,7 +431,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934427,
+    "wof:lastmodified":1695884337,
     "wof:name":"Hamadan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/61/85672361.geojson
+++ b/data/856/723/61/85672361.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.193908,
-    "geom:area_square_m":21806699862.377892,
+    "geom:area_square_m":21806699450.040035,
     "geom:bbox":"47.176611,35.551784,49.432129,37.251618",
     "geom:latitude":36.499599,
     "geom:longitude":48.385101,
@@ -388,17 +388,19 @@
         "gn:id":111452,
         "gp:id":2345786,
         "hasc:id":"IR.ZA",
+        "iso:code":"IR-11",
         "iso:id":"IR-11",
         "qs_pg:id":318517,
         "unlc:id":"IR-11",
         "wd:id":"Q146726",
         "wk:page":"Zanjan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cf643c95d16de19ac31f7784075335b4",
+    "wof:geomhash":"ceb59fc97f1a5d882cef8a9f96663afa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -413,7 +415,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934421,
+    "wof:lastmodified":1695884335,
     "wof:name":"Zanjan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/67/85672367.geojson
+++ b/data/856/723/67/85672367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.550083,
-    "geom:area_square_m":15489190503.327213,
+    "geom:area_square_m":15489191391.366732,
     "geom:bbox":"48.725448,35.40135,50.855495,36.764986",
     "geom:latitude":36.086471,
     "geom:longitude":49.767954,
@@ -390,16 +390,18 @@
         "gn:id":443793,
         "gp:id":20070200,
         "hasc:id":"IR.QZ",
+        "iso:code":"IR-28",
         "iso:id":"IR-28",
         "qs_pg:id":896387,
         "wd:id":"Q1105893",
         "wk:page":"Qazvin Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"735062915a66d8b7101bbab45a4d5a5e",
+    "wof:geomhash":"d45176b4547d1fd06e4204339f9f2cc4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -414,7 +416,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934422,
+    "wof:lastmodified":1695884336,
     "wof:name":"Qazvin",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/69/85672369.geojson
+++ b/data/856/723/69/85672369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.783672,
-    "geom:area_square_m":37031167938.384079,
+    "geom:area_square_m":37031166749.414391,
     "geom:bbox":"44.031891,35.967743,47.391591,39.781676",
     "geom:latitude":37.661374,
     "geom:longitude":45.340976,
@@ -398,17 +398,19 @@
         "gn:id":142550,
         "gp:id":2345767,
         "hasc:id":"IR.WA",
+        "iso:code":"IR-02",
         "iso:id":"IR-02",
         "qs_pg:id":890076,
         "unlc:id":"IR-02",
         "wd:id":"Q134411",
         "wk:page":"West Azerbaijan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"98097f9c8bdd4adf3c65d421408d1bf4",
+    "wof:geomhash":"790de8e25b1157376a2bf6b24a2957f5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -423,7 +425,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934421,
+    "wof:lastmodified":1695884335,
     "wof:name":"West Azerbaijan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/73/85672373.geojson
+++ b/data/856/723/73/85672373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.158637,
-    "geom:area_square_m":50275836847.169968,
+    "geom:area_square_m":50275835805.635063,
     "geom:bbox":"45.001173,36.744467,48.339168,39.426777",
     "geom:latitude":37.980747,
     "geom:longitude":46.589922,
@@ -407,17 +407,19 @@
         "gn:id":142549,
         "gp:id":2345768,
         "hasc:id":"IR.EA",
+        "iso:code":"IR-01",
         "iso:id":"IR-01",
         "qs_pg:id":890077,
         "unlc:id":"IR-01",
         "wd:id":"Q176081",
         "wk:page":"East Azerbaijan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b7e2f20aae7705ab0c32130e8fe74781",
+    "wof:geomhash":"8a56133fb121fa42450623551f912120",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -432,7 +434,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934424,
+    "wof:lastmodified":1695884336,
     "wof:name":"East Azerbaijan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/79/85672379.geojson
+++ b/data/856/723/79/85672379.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.446904,
-    "geom:area_square_m":24954582147.48238,
+    "geom:area_square_m":24954580665.39695,
     "geom:bbox":"45.407661,33.686391,48.1037,35.282571",
     "geom:latitude":34.433495,
     "geom:longitude":46.686665,
@@ -396,17 +396,19 @@
         "gn:id":128222,
         "gp:id":2345777,
         "hasc:id":"IR.BK",
+        "iso:code":"IR-17",
         "iso:id":"IR-17",
         "qs_pg:id":219563,
         "unlc:id":"IR-17",
         "wd:id":"Q174010",
         "wk:page":"Kermanshah Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5b20c186a46602ff238340c016167612",
+    "wof:geomhash":"d46fe5604f93ce107a06849d92c994fe",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -421,7 +423,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934428,
+    "wof:lastmodified":1695884793,
     "wof:name":"Kermanshah",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/83/85672383.geojson
+++ b/data/856/723/83/85672383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.423045,
-    "geom:area_square_m":14006437209.333405,
+    "geom:area_square_m":14006437792.869978,
     "geom:bbox":"48.569675,36.560897,50.59595,38.451999",
     "geom:latitude":37.248983,
     "geom:longitude":49.4951,
@@ -411,17 +411,19 @@
         "gn:id":133349,
         "gp:id":2345773,
         "hasc:id":"IR.GI",
+        "iso:code":"IR-19",
         "iso:id":"IR-19",
         "qs_pg:id":894891,
         "unlc:id":"IR-19",
         "wd:id":"Q928828",
         "wk:page":"Gilan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9b9ca273f9a37640bc3b9e48f070b7c8",
+    "wof:geomhash":"09172c1685dc3def952c90c123452e2f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -436,7 +438,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934429,
+    "wof:lastmodified":1695884338,
     "wof:name":"Gilan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/87/85672387.geojson
+++ b/data/856/723/87/85672387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.893032,
-    "geom:area_square_m":29055859320.963009,
+    "geom:area_square_m":29055858941.897617,
     "geom:bbox":"45.551037,34.740806,48.248984,36.463057",
     "geom:latitude":35.683401,
     "geom:longitude":46.98237,
@@ -411,17 +411,19 @@
         "gn:id":126584,
         "gp:id":2345779,
         "hasc:id":"IR.KD",
+        "iso:code":"IR-16",
         "iso:id":"IR-16",
         "qs_pg:id":423772,
         "unlc:id":"IR-16",
         "wd:id":"Q134386",
         "wk:page":"Kurdistan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8c9eb3b1935edd9861d17c5fdca6de76",
+    "wof:geomhash":"c5a607ab97aa45208162fde51774a4f6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -436,7 +438,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934424,
+    "wof:lastmodified":1695884337,
     "wof:name":"Kordestan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/91/85672391.geojson
+++ b/data/856/723/91/85672391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":14.401037,
-    "geom:area_square_m":149465932498.847931,
+    "geom:area_square_m":149465930645.490631,
     "geom:bbox":"55.3877,30.517222,60.947515,35.097995",
     "geom:latitude":32.914965,
     "geom:longitude":58.329529,
@@ -420,15 +420,17 @@
         "gn:id":6201374,
         "gp:id":56189825,
         "hasc:id":"IR.KJ",
+        "iso:code":"IR-29",
         "iso:id":"IR-29",
         "qs_pg:id":909770,
         "wd:id":"Q171551"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1d8833ae2f50152b9c6f33dd6eef6012",
+    "wof:geomhash":"78cd741d1664b2893a21c65ad1f6d4e7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -443,7 +445,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934426,
+    "wof:lastmodified":1695884337,
     "wof:name":"South Khorasan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/723/97/85672397.geojson
+++ b/data/856/723/97/85672397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":11.72743,
-    "geom:area_square_m":117784384561.601913,
+    "geom:area_square_m":117784386754.517151,
     "geom:bbox":"56.229356,33.857637,61.283935,37.70523",
     "geom:latitude":35.675753,
     "geom:longitude":59.052123,
@@ -428,14 +428,16 @@
         "gn:id":6201375,
         "gp:id":2345789,
         "hasc:id":"IR.KV",
+        "iso:code":"IR-30",
         "iso:id":"IR-30",
         "wd:id":"Q587090"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a5237cbc6dd6310747e880ca60c16b92",
+    "wof:geomhash":"1f788089761d6b07d06d83d118b68b3b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -450,7 +452,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934428,
+    "wof:lastmodified":1695884337,
     "wof:name":"Razavi Khorasan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/724/01/85672401.geojson
+++ b/data/856/724/01/85672401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.865737,
-    "geom:area_square_m":28146613824.931839,
+    "geom:area_square_m":28146614912.23867,
     "geom:bbox":"55.90808,36.580262,58.420482,38.286124",
     "geom:latitude":37.408302,
     "geom:longitude":57.136177,
@@ -415,14 +415,16 @@
         "gn:id":6201376,
         "gp:id":-56189824,
         "hasc:id":"IR.KS",
+        "iso:code":"IR-31",
         "iso:id":"IR-31",
         "wd:id":"Q180075"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6ff2404aca97670b65575985a2cd00d9",
+    "wof:geomhash":"e4060e613ce2705ca8d5efaee2cbc084",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -437,7 +439,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934420,
+    "wof:lastmodified":1695884335,
     "wof:name":"North Khorasan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/724/05/85672405.geojson
+++ b/data/856/724/05/85672405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":16.327875,
-    "geom:area_square_m":178330179382.650421,
+    "geom:area_square_m":178330180139.355804,
     "geom:bbox":"58.828632,25.060389,63.333201,31.485727",
     "geom:latitude":27.919372,
     "geom:longitude":60.728738,
@@ -441,17 +441,19 @@
         "gn:id":1159456,
         "gp:id":2345770,
         "hasc:id":"IR.SB",
+        "iso:code":"IR-13",
         "iso:id":"IR-13",
         "qs_pg:id":890079,
         "unlc:id":"IR-13",
         "wd:id":"Q939575",
         "wk:page":"Sistan and Baluchestan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2915a9f1ccbc402b09400f0eca2b5d8f",
+    "wof:geomhash":"118ad090c4d0faff24aa9afe12e5763e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -466,7 +468,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934419,
+    "wof:lastmodified":1695884334,
     "wof:name":"Sistan and Baluchestan",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/724/09/85672409.geojson
+++ b/data/856/724/09/85672409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":16.697576,
-    "geom:area_square_m":179454302043.829346,
+    "geom:area_square_m":179454301243.881897,
     "geom:bbox":"54.337815,26.481747,59.569391,31.960169",
     "geom:latitude":29.616546,
     "geom:longitude":57.297204,
@@ -396,17 +396,19 @@
         "gn:id":128231,
         "gp:id":2345788,
         "hasc:id":"IR.KE",
+        "iso:code":"IR-15",
         "iso:id":"IR-15",
         "qs_pg:id":318519,
         "unlc:id":"IR-15",
         "wd:id":"Q165352",
         "wk:page":"Kerman Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"67a1bb32cdea3f8074fbd69d4d11cf12",
+    "wof:geomhash":"723e439655c2c5a1edceb237412c8e96",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -421,7 +423,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934419,
+    "wof:lastmodified":1695884335,
     "wof:name":"Kerman",
     "wof:parent_id":85632361,
     "wof:placetype":"region",

--- a/data/856/724/15/85672415.geojson
+++ b/data/856/724/15/85672415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.511734,
-    "geom:area_square_m":5121116180.479005,
+    "geom:area_square_m":5121115933.109932,
     "geom:bbox":"50.163551,35.543414,51.463322,36.34181",
     "geom:latitude":35.970239,
     "geom:longitude":50.805406,
@@ -385,15 +385,17 @@
         "gn:id":7648907,
         "gp:id":-20070200,
         "hasc:id":"IR.AL",
+        "iso:code":"IR-32",
         "iso:id":"IR-32",
         "unlc:id":"IR-32",
         "wd:id":"Q484725"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"67f4b9095abb10567d1c864fccff6f67",
+    "wof:geomhash":"c12248f077363f5a472d679af3f04b7b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -408,7 +410,7 @@
     "wof:lang_x_spoken":[
         "fas"
     ],
-    "wof:lastmodified":1690934420,
+    "wof:lastmodified":1695884335,
     "wof:name":"Alborz",
     "wof:parent_id":85632361,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.